### PR TITLE
Add extra deps

### DIFF
--- a/odoo80/Dockerfile
+++ b/odoo80/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update -q && apt-get upgrade -q \
     xsltproc \
     xmlstarlet \
     openssl \
-    python-libxml2
+    python-libxml2 \
+    phantomjs
 RUN ln -s /usr/include/freetype2 /usr/local/include/freetype \
     && ln -s /usr/lib/x86_64-linux-gnu/libjpeg.so /usr/lib/ \
     && ln -s /usr/lib/x86_64-linux-gnu/libfreetype.so /usr/lib/ \

--- a/odoo80/Dockerfile
+++ b/odoo80/Dockerfile
@@ -49,4 +49,6 @@ RUN cd /tmp \
     && sh 05-install-dependencies-python-v80.sh
 RUN wget -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
     && gunzip GeoLiteCity.dat.gz && mkdir -p /usr/share/GeoIP && mv GeoLiteCity.dat /usr/share/GeoIP/GeoLiteCity.dat
+RUN cd /tmp && wget -O wkhtmltox-0.12.1_linux-trusty-amd64.deb http://iweb.dl.sourceforge.net/project/wkhtmltopdf/archive/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb \
+    && dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*


### PR DESCRIPTION
Added phantomjs because is needed for tests besides the base image is not intended for tests environments could be usefull for running local tests-

wkhtmltopdf added 0.12.1 version so there is not more warns because of this when starting instances, also this specific version is widely test