### PR TITLE
[REF] dockerlint has a more descriptive log for error than docklint, …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "4.1"
 
 install:
-  - npm install -g validate-dockerfile
+  - npm install -g dockerlint
 
 script:
-  - for dfile in `find $TRAVIS_BUILD_DIR -name 'Dockerfile' -not -path "./.git/*"`; do echo " ===== [ CHECKING $dfile ] ===== "; docklint $dfile; if [ $? -ne 0 ]; then return 1; fi; echo ""; done
+  - for dfile in `find $TRAVIS_BUILD_DIR -name 'Dockerfile' -not -path "./.git/*"`; do echo " ===== [ CHECKING $dfile ] ===== "; dockerlint $dfile; if [ $? -ne 0 ]; then echo " ----- [ FINISHED IN ERROR ] ----- "; fi; echo ""; done


### PR DESCRIPTION
with this comparison:

## Dockerlint
```bash
 ===== [ CHECKING ./odoo70/Dockerfile ] ===== 

INFO: ./odoo70/Dockerfile is OK.


 ===== [ CHECKING ./odoo61/Dockerfile ] ===== 

INFO: ./odoo61/Dockerfile is OK.


 ===== [ CHECKING ./odoo-shippable/Dockerfile ] ===== 
WARN:  sudo(8) usage found on line 12 which is discouraged

ERROR: ./odoo-shippable/Dockerfile failed.

 ----- [ FINISHED IN ERROR ] ----- 

 ===== [ CHECKING ./odoo80/Dockerfile ] ===== 
WARN:  sudo(8) usage found on line 55 which is discouraged

ERROR: ./odoo80/Dockerfile failed.

 ----- [ FINISHED IN ERROR ] ----- 
```

vs
## Docklint
```bash
 ===== [ CHECKING ./odoo70/Dockerfile ] ===== 
VALIDATION FAILED
Invalid instruction
at line 20
Missing CMD
 ----- [ FINISHED IN ERROR ] ----- 

 ===== [ CHECKING ./odoo61/Dockerfile ] ===== 
VALIDATION FAILED
Missing CMD
 ----- [ FINISHED IN ERROR ] ----- 

 ===== [ CHECKING ./odoo-shippable/Dockerfile ] ===== 
VALIDATION FAILED
Invalid instruction
at line 136
Invalid instruction
at line 138
Invalid instruction
at line 140
Missing CMD
 ----- [ FINISHED IN ERROR ] ----- 

 ===== [ CHECKING ./odoo80/Dockerfile ] ===== 
VALIDATION FAILED
Missing CMD
 ----- [ FINISHED IN ERROR ] ----- 
``` 

I propose to use **dockerlint** https://github.com/RedCoolBeans/dockerlint