### PR TITLE
[REF] odoo-shippable: Fix vim lua error 

### DIFF
--- a/odoo-shippable/Dockerfile
+++ b/odoo-shippable/Dockerfile
@@ -99,10 +99,12 @@ RUN touch /usr/bin/travis_wait \
 RUN apt-get install -y expect-dev
 
 # Install spf13 for vim, fix comments hidden, fix select text
+#  and install lua (required by vim-neocomplete)
 RUN curl http://j.mp/spf13-vim3 -L -o - | sh \
   && echo colorscheme ir_black >> ${HOME}/.vimrc \
   && echo 'let &colorcolumn=join(range(80,999),",")' >> ${HOME}/.vimrc \
-  && sed -i 's/ set mouse\=a/\"set mouse\=a/g' ${HOME}/.vimrc
+  && sed -i 's/ set mouse\=a/\"set mouse\=a/g' ${HOME}/.vimrc \
+  && apt-get install lua50 liblua50-dev liblualib50-dev
 
 # Install extra-developer-packages
 RUN apt-get install -y mosh bpython \


### PR DESCRIPTION
Fix vim error `neocomplete requires Vim 7.3.885 or later with Lua support ("+lua")`