### PR TITLE
[IMP] Added suppor for postgres 9.5 and multi version

### DIFF
--- a/odoo-shippable/Dockerfile
+++ b/odoo-shippable/Dockerfile
@@ -19,16 +19,40 @@ RUN sudo useradd -d /home/shippable -m -s /bin/bash -p shippablepwd shippable \
 RUN git config --global user.name Shippable \
     && git config --global user.email hello@shippable.com
 
-# Install basic postgres
-RUN sudo apt-get update \
-    && sudo apt-get install -y postgresql-9.3 postgresql-contrib-9.3
-RUN sed -i 's/#max_pred_locks_per_transaction = 64/max_pred_locks_per_transaction = 100/g' /etc/postgresql/*/main/postgresql.conf
-RUN sed -i 's/max_connections = 100/max_connections = 200/g' /etc/postgresql/*/main/postgresql.conf
+# Install postgres common files
+RUN sudo apt-get install postgresql-common
 
-# Create shippable role to postgres and shippable
+# Do not create postgres main clusters so we can name them mainVV where VV is postgres persion 93 or 95 do far
+RUN sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf
+
+# Install basic postgres 9.3 and 9.5
+RUN sudo apt-get update \
+    && sudo apt-get install -y postgresql-9.3 postgresql-contrib-9.3 \
+    postgresql-9.5 postgresql-contrib-9.5
+
+# Create the clusters with the proper naming
+RUN pg_createcluster 9.3 main93 -e=utf8
+
+RUN pg_createcluster 9.5 main95 -e=utf8
+
+RUN sed -i 's/#max_pred_locks_per_transaction = 64/max_pred_locks_per_transaction = 100/g' /etc/postgresql/*/main*/postgresql.conf
+RUN sed -i 's/max_connections = 100/max_connections = 200/g' /etc/postgresql/*/main*/postgresql.conf
+RUN sed -i 's/^port = .*/port = 5432/g' /etc/postgresql/*/main*/postgresql.conf
+
+ENV PSQL_VERSION 9.5
+# Create shippable role to postgres and shippable for postgres 9.5
 RUN /entrypoint_image \
     && su - postgres -c "psql -c  \"CREATE ROLE shippable LOGIN PASSWORD 'aeK5NWNr2' SUPERUSER INHERIT CREATEDB CREATEROLE;\"" \
     && su - postgres -c "psql -c  \"CREATE ROLE root LOGIN PASSWORD 'aeK5NWNr' SUPERUSER INHERIT CREATEDB CREATEROLE;\""
+RUN /etc/init.d/postgresql stop
+
+ENV PSQL_VERSION 9.3
+# Create shippable role to postgres and shippable for postgres 9.3, as the version is not changed from this point on
+# default will be 9.3 unless overriden
+RUN /entrypoint_image \
+    && su - postgres -c "psql -c  \"CREATE ROLE shippable LOGIN PASSWORD 'aeK5NWNr2' SUPERUSER INHERIT CREATEDB CREATEROLE;\"" \
+    && su - postgres -c "psql -c  \"CREATE ROLE root LOGIN PASSWORD 'aeK5NWNr' SUPERUSER INHERIT CREATEDB CREATEROLE;\""
+
 
 # Install some depends
 ##MX PACKAGES

--- a/odoo-shippable/files/entrypoint_image
+++ b/odoo-shippable/files/entrypoint_image
@@ -34,8 +34,12 @@ def docker_entrypoint():
     subprocess.Popen(sub_cmd2, stdin=subp1.stdout, stdout=subprocess.PIPE)
 
     # Start postgresql service
-    cmd = '/etc/init.d/postgresql start'
-    subprocess.Popen(cmd, shell=True)
+
+    psql_version = os.environ.get('PSQL_VERSION', '9.3')
+    psql_vstr = psql_version.replace('.', '')
+    cmd = '/etc/init.d/postgresql start {version} main{psql_version}'.format(version=psql_version, psql_version=psql_vstr)
+    ppostgres = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    ppostgres.wait()
     print("Waiting to start psql service...")
     count = 0
     max_count = 40


### PR DESCRIPTION
@moylop260 

Executed 2 container using the env vars:
![env](http://i.imgur.com/QZJ4tKh.png)

Both containers running
![running](http://i.imgur.com/jWOTegM.png)

Executing Psql 9.3:
![93](http://i.imgur.com/kxUNsTD.png)

Executing Psql 9.5:
![95](http://i.imgur.com/Qeg29iK.png)

With no env var (uses 9.3 as default):
![default](http://i.imgur.com/AUBoqi3.png)

![default_psql](http://i.imgur.com/44WkC8S.png)

As it was updated the client is now V 9.5, but the server is 9.5 or 9.3 according to the PSQL_VERSION env var, for back compatibility if no env var is given will use 9.3 by default

I changed the cluster default name to avoid conflicts even if you decice to use both versions at the same time (but the post must be changed).

The sed changing the port is necessary because pgcreatecluster don't allow me to create another cluster with the same port even when none cluster is running.

Also, added the ppostgres.wait() so it actually waits until the cluster is up, I had some issues because delayed a little to start, so decided to change this.