### PR TITLE
[FIX] odoo-shippable: Fix slow prompt in big git workdir

### DIFF
--- a/odoo-shippable/files/bash_colors
+++ b/odoo-shippable/files/bash_colors
@@ -76,17 +76,27 @@ PathShort="\w"
 PathFull="\W"
 NewLine="\n"
 Jobs="\j"
-UserMachine="$BIPurple[\u@$Purple\h:]"
+UserMachine="$BIPurple[\u@$Purple\h]"
 
-export PS1=$UserMachine$Color_Off$PathShort'\$ $(git branch &>/dev/null;\
-if [ $? -eq 0 ]; then \
-  echo "$(echo `git status` | grep "nothing to commit" > /dev/null 2>&1; \
-  if [ "$?" -eq "0" ]; then \
-    # @4 - Clean repository - nothing to commit
-    echo "\n'$Green'"$(__git_ps1 "(%s)"'$Color_Off'); \
-  else \
-    # @5 - Changes to working tree
-    echo "\n'$IRed'"$(__git_ps1 "(%s)"'$Color_Off'); \
-  fi)\$ "; \
-fi)'
+# Color scape to use in methods: http://stackoverflow.com/questions/22706538/getting-a-dynamic-bash-prompt-ps1-right
+GREEN_WOE="\001\033[0;32m\002"
+RED_WOE="\001\033[0;91m\002"
+
+git_ps1_style ()
+{
+    local git_branch="$(__git_ps1 2>/dev/null)";
+    local git_ps1_style="";
+    if [ -n "$git_branch" ]; then
+        (git diff --quiet --ignore-submodules HEAD 2>/dev/null)
+        local git_changed=$?
+        if [ "$git_changed" == 0 ]; then
+            git_ps1_style=$GREEN_WOE$git_branch;
+        else
+            git_ps1_style=$RED_WOE$git_branch;
+        fi
+    fi
+    echo -e "$git_ps1_style"
+}
+
+export PS1=$UserMachine$Color_Off$PathShort\$\\n"\$(git_ps1_style)"$Color_Off\$" "
 


### PR DESCRIPTION
Currently the script to get `git status` to set the color of the branch in the prompt (red or green) is very slow with bigger git directories.

I used follow gist: https://gist.github.com/sindresorhus/3898739 to fix performance.
This script work very similar but faster.

Example:

Without changes:
![screen shot 2016-02-12 at 9 44 35 pm](https://cloud.githubusercontent.com/assets/6644187/13025625/d987104a-d1d1-11e5-887a-bfaf48d49e1c.png)

With changes in versioned file:
![screen shot 2016-02-12 at 9 45 08 pm](https://cloud.githubusercontent.com/assets/6644187/13025629/ee5b97ca-d1d1-11e5-8bc7-4cd7c2b4d524.png)

With changes in unversioned file:
![screen shot 2016-02-12 at 9 46 01 pm](https://cloud.githubusercontent.com/assets/6644187/13025633/0b6a066c-d1d2-11e5-9f5f-b35ac688a431.png)
Here the difference: We have a green branch with unversioned files.

When you execute a `git add` then now is red:
![screen shot 2016-02-12 at 9 49 49 pm](https://cloud.githubusercontent.com/assets/6644187/13025659/91ad6bec-d1d2-11e5-9d0e-0fbc073b2f71.png)

This is a disadvantage but IMHO the performance issue is a greater problem.