### PR TITLE
[REF] odoo-shippable: Use of database cluster standard name and start service standard

### DIFF
--- a/odoo-shippable/Dockerfile
+++ b/odoo-shippable/Dockerfile
@@ -3,6 +3,7 @@ FROM vauxoo/odoo-80-image
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 COPY files/entrypoint_image /entrypoint_image
 COPY files/bash_colors /root/.bash_colors
+COPY files/etc_initd_postgresql /tmp/etc_initd_postgresql
 
 ENV RUN_COMMAND_MQT_10_ENTRYPOINT_IMAGE="/entrypoint_image" \
     INSTANCE_ALIVE="1" PSQL_VERSION="9.3" \
@@ -26,9 +27,11 @@ RUN apt-get update && apt-get install postgresql-common \
     && sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
     && apt-get install -y postgresql-9.3 postgresql-contrib-9.3 \
     postgresql-9.5 postgresql-contrib-9.5 perl-modules make \
+    && mv /tmp/etc_initd_postgresql /etc/init.d/postgresql \
+    && chmod +x /etc/init.d/postgresql \
     && rm -rf /var/lib/apt/lists/* \
-    && pg_createcluster 9.3 main93 -e=utf8 \
-    && pg_createcluster 9.5 main95 -e=utf8 \
+    && pg_createcluster 9.3 main -e=utf8 \
+    && pg_createcluster 9.5 main -e=utf8 \
     && sed -i 's/#max_pred_locks_per_transaction = 64/max_pred_locks_per_transaction = 100/g' /etc/postgresql/*/main*/postgresql.conf \
     && sed -i 's/max_connections = 100/max_connections = 200/g' /etc/postgresql/*/main*/postgresql.conf \
     && sed -i 's/^port = .*/port = 5432/g' /etc/postgresql/*/main*/postgresql.conf \

--- a/odoo-shippable/files/entrypoint_image
+++ b/odoo-shippable/files/entrypoint_image
@@ -62,11 +62,8 @@ def docker_entrypoint():
         subprocess.call(cmd, shell=True)
 
     # Start postgresql service
-    psql_version = os.environ.get('PSQL_VERSION', '9.3')
-    psql_vstr = psql_version.replace('.', '')
-    cmd = '/etc/init.d/postgresql start {version} main{psql_version}'.format(
-        version=psql_version, psql_version=psql_vstr)
-    subprocess.call(cmd, shell=True)
+    cmd = '/etc/init.d/postgresql start'
+    subprocess.call(cmd, shell=True, env=os.environ)
     print("Waiting to start psql service...")
     count = 0
     max_count = 120

--- a/odoo-shippable/files/etc_initd_postgresql
+++ b/odoo-shippable/files/etc_initd_postgresql
@@ -1,0 +1,100 @@
+#!/bin/sh
+set -e
+
+### BEGIN INIT INFO
+# Provides:             postgresql
+# Required-Start:       $local_fs $remote_fs $network $time
+# Required-Stop:        $local_fs $remote_fs $network $time
+# Should-Start:         $syslog
+# Should-Stop:          $syslog
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    PostgreSQL RDBMS server
+### END INIT INFO
+
+# Setting environment variables for the postmaster here does not work; please
+# set them in /etc/postgresql/<version>/<cluster>/environment instead.
+
+[ -r /usr/share/postgresql-common/init.d-functions ] || exit 0
+
+. /usr/share/postgresql-common/init.d-functions
+
+# ##########################################################
+# SECTION BASED ON TRAVIS-CI CONFIGURATION FROM DOCKER IMAGE
+#   quay.io/travisci/travis-python
+# ##########################################################
+# ORIGINAL version management disabled for Travis CI specific needs, see below
+# versions can be specified explicitly
+#if [ -n "$2" ]; then
+#    versions="$2 $3 $4 $5 $6 $7 $8 $9"
+#else
+#    get_versions
+#fi
+
+# there should be only one running instance, and we must act in consequence...
+running_version=$(pg_lsclusters -h | grep online | awk '{print $1}')
+
+if [ -n "$2" ]; then
+    versions="$2"
+elif [ -n "$1" ] && [ $1 = 'stop' ]; then
+    # be 100% sure to stop all instances (robustness hack)
+    get_versions
+elif [ -n "$running_version"  ]; then
+    versions="$running_version"
+elif [ -n "$PSQL_VERSION" ]; then
+   # Use of a environment variable to get POSTGRESQL VERSION
+   versions=$PSQL_VERSION
+else
+    versions="9.3"
+fi
+
+if [ -n "$1" ] && [ $1 != 'stop' ] && [ $1 != 'status' ]; then
+    if [ -n "$running_version" ] && [ "$versions" != "$running_version" ]; then
+        echo "Refused to $1 PostgreSQL $versions, because PostgreSQL $running_version is currently running! You should first stop $running_version instance..."
+        exit 13
+    fi
+    if [ ! -d "/etc/postgresql/$versions" ]; then
+        echo "PostgreSQL $versions is not installed!"
+        exit 31
+    fi
+fi
+
+# Copy initial databases to RAMFS
+for data_dir in /var/lib/postgresql/*; do
+    v=$(basename $data_dir)
+    if [ -d $(dirname /var/ramfs/postgresql) -a ! -d /var/ramfs/postgresql/$v ]; then
+        mkdir -p /var/ramfs/postgresql/$v
+        cp -rp $data_dir /var/ramfs/postgresql/
+    fi
+done
+
+case "$1" in
+    start|stop|restart|reload)
+        if [ -z "`pg_lsclusters -h`" ]; then
+            log_warning_msg 'No PostgreSQL clusters exist; see "man pg_createcluster"'
+            exit 0
+        fi
+        for v in $versions; do
+            $1 $v || EXIT=$?
+        done
+        exit ${EXIT:-0}
+        ;;
+    status)
+        LS=`pg_lsclusters -h`
+        # no clusters -> unknown status
+        [ -n "$LS" ] || exit 4
+        echo "$LS" | awk 'BEGIN {rc=3} {if (match($4, "online")) rc=0; printf ("%s/%s (port %s): %s\n", $1, $2, $3, $4)}; END {exit rc}'
+        ;;
+    force-reload)
+        for v in $versions; do
+            reload $v
+        done
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|reload|force-reload|status} [version ..]"
+        exit 1
+        ;;
+esac
+
+exit 0
+


### PR DESCRIPTION
 - Based on docker image `quay.io/travisci/travis-python` to unified the use of CI script from MQT.
 - Use of same path like as travis: `/etc/postgresql/9.X/main`
 - Allow start/stop/restart postgresql service with `/etc/init.d/postgresql start` without a parameter additional (or one parameter if is required).
<img width="1256" alt="screen shot 2016-03-13 at 10 27 03 pm" src="https://cloud.githubusercontent.com/assets/6644187/13735075/c2655d3a-e96a-11e5-8be5-99c40465e505.png">
 - Avoid start two psql server:
<img width="1268" alt="screen shot 2016-03-13 at 10 31 29 pm" src="https://cloud.githubusercontent.com/assets/6644187/13735128/7403e4b2-e96b-11e5-9b68-6d034d6edef7.png">
