### PR TITLE
[FIX] Install pycrypto and allow the python-dev to be installed in the base image

### DIFF
--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -19,6 +19,7 @@ DEPENDENCIES_FILE="$( mktemp -d )/odoo-requirements.txt"
 DPKG_DEPENDS="nodejs \
               phantomjs \
               antiword \
+              python-dev \
               poppler-utils \
               xmlstarlet \
               xsltproc \
@@ -33,6 +34,7 @@ NPM_DEPENDS="less \
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="pyyaml \
+                   pycrypto \
                    pillow \
                    pillow-pil \
                    M2Crypto \
@@ -55,7 +57,6 @@ PIP_DEPENDS_EXTRA="pyyaml \
 PIP_DPKG_BUILD_DEPENDS="build-essential \
                         gfortran \
                         cython \
-                        python-dev \
                         libfreetype6-dev \
                         zlib1g-dev \
                         libjpeg-dev \

--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -25,7 +25,9 @@ DPKG_DEPENDS="nodejs \
               xsltproc \
               xz-utils \
               swig \
-              geoip-database-contrib"
+              geoip-database-contrib \
+              build-essential \
+              cython"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \
@@ -34,7 +36,6 @@ NPM_DEPENDS="less \
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="pyyaml \
-                   pycrypto \
                    pillow \
                    pillow-pil \
                    M2Crypto \
@@ -54,9 +55,7 @@ PIP_DEPENDS_EXTRA="pyyaml \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
                    git+https://github.com/vauxoo/panama-dv@master#egg=ruc"
-PIP_DPKG_BUILD_DEPENDS="build-essential \
-                        gfortran \
-                        cython \
+PIP_DPKG_BUILD_DEPENDS="gfortran \
                         libfreetype6-dev \
                         zlib1g-dev \
                         libjpeg-dev \


### PR DESCRIPTION
Yesterday I was trying to generate the instance for one of ours customer and the following error was raised:
![error](http://screenshots.vauxoo.com/tulio/12114513316-hvoOGKYs2u.jpg)

Then when I tried to install the package:

![error](http://screenshots.vauxoo.com/tulio/12120913316-hyvtqRLmYI.jpg)

@moylop260  the pycryto package is a dependency from [OMLv2](https://github.com/Vauxoo/odoo-mexico-v2/blob/8.0/l10n_mx_facturae_lib/__openerp__.py#L38), but it is not listed in the [requirements](https://github.com/Vauxoo/odoo-mexico-v2/blob/8.0/requirements.txt) file.

@LuisAlejandro besides, python-dev package is one of those that we may not need to use a lot, but since we all work (or at least most of us) with python there are a few libs that depend of it. If we want to update some of those packages we'll have to install it over and over (the idea of this image is to avoid it whenever possible)

I tested the changes in the commit and the installation process was successful with no additional changes:
![install](http://screenshots.vauxoo.com/tulio/13322713316-3gBCrW0eDv.jpg)

And the python-dev packages is installed:

![python](http://screenshots.vauxoo.com/tulio/13200313316-vp73cuaNKl.jpg)

