### PR TITLE
[FIX] Fix the webkit version to the one that we already have working

### DIFF
--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -7,12 +7,12 @@ set -e
 # With a little help from my friends
 . /usr/share/vx-docker-internal/ubuntu-base/library.sh
 . /usr/share/vx-docker-internal/odoo80/library.sh
-
+. /etc/lsb-release
 # Let's set some defaults here
 ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-WKHTMLTOX_URL="http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-${ARCH}.tar.xz"
+WKHTMLTOX_URL="http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-${DISTRIB_CODENAME}-${ARCH}.deb"
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@8.0 \
                    git+https://github.com/vauxoo/server-tools@8.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@8.0 \
@@ -43,7 +43,8 @@ DPKG_DEPENDS="nodejs \
               libxml2-dev \
               libxslt1-dev \
               libgeoip-dev \
-              cython"
+              cython \
+              fontconfig"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \

--- a/odoo80/scripts/library.sh
+++ b/odoo80/scripts/library.sh
@@ -81,7 +81,7 @@ function collect_pip_dependencies(){
 function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
-    wget -qO- "${URL}" | tar -xJ -C "${DIR}/"
-    mv "${DIR}/wkhtmltox/bin/wkhtmltopdf" "/usr/local/bin/wkhtmltopdf"
-    rm -rf "${DIR}"
+    wget -q "${URL}" -O wkhtmltox.deb
+    dpkg -i wkhtmltox.deb
+    rm wkhtmltox.deb
 }


### PR DESCRIPTION
This fixes the issues we are having with reports in lodi and others.

@nhomar @moylop260 we _cannot_ change this versions until we have everything fully tested, we had an issue in Wohlert because of this. If the idea is to improve what we already had working is ok to me, but if we are going to migrate to new versions we need a better plan that must involve the whole team so they can make the proper tests before applying this into production.

It was my bad not to check the proper package version, but still, we cannot change the fixed package versions (we had very sad times when we do this :( ) they're fixed for a very good reason (most of the time)
