### PR TITLE
[IMP] docker-odoo-image: Enable pylint_odoo python checks into the vi…

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -134,6 +134,23 @@ set colorcolumn=80
 set spelllang=en,es
 EOF
 
+# Configure pylint_odoo plugin and the .conf file
+# to enable python pylint_odoo checks into the vim editor.
+cat >> /root/.vimrc << EOF
+:filetype on                                                                    
+let g:syntastic_python_checkers = ['pylint']                                    
+let g:syntastic_python_pylint_args =                                            
+    \ '--load-plugins=pylint_odoo -e odoolint'                                  
+function! FindConfig(prefix, what, where)                                       
+    let cfg = findfile(a:what, escape(a:where, ' ') . ';')                      
+    return cfg !=# '' ? ' ' . a:prefix . ' ' . cfg : ''                         
+endfunction                                                                     
+                                                                                
+autocmd FileType python let b:syntastic_python_pylint_args =                    
+    \ get(g:, 'syntastic_python_pylint_args', '') .                             
+    \ FindConfig('-c', 'pylint_vauxoo_light_pr.cfg', expand('<amatch>:p:h', 1))
+EOF
+
 cat >> /root/.vimrc.bundles << EOF
 " Odoo snippets {
 if count(g:spf13_bundle_groups, 'odoovim')

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -98,6 +98,7 @@ git_clone_copy "${MQT_REPO}" "master" "" "${REPO_REQUIREMENTS}/linit_hook"
 git_clone_copy "${PYLINT_REPO}" "master" "conf/pylint_vauxoo_light.cfg" "${REPO_REQUIREMENTS}/linit_hook/travis/cfg/travis_run_pylint.cfg"
 git_clone_copy "${PYLINT_REPO}" "master" "conf/pylint_vauxoo_light_pr.cfg" "${REPO_REQUIREMENTS}/linit_hook/travis/cfg/travis_run_pylint_pr.cfg"
 git_clone_copy "${PYLINT_REPO}" "master" "conf/pylint_vauxoo_light_beta.cfg" "${REPO_REQUIREMENTS}/linit_hook/travis/cfg/travis_run_pylint_beta.cfg"
+git_clone_copy "${PYLINT_REPO}" "master" "conf/pylint_vauxoo_light_vim.cfg" "${REPO_REQUIREMENTS}/linit_hook/travis/cfg/travis_run_pylint_vim.cfg"
 ln -sf ${REPO_REQUIREMENTS}/linit_hook/git/* /usr/share/git-core/templates/hooks/
 
 # Execute travis_install_nightly
@@ -138,17 +139,13 @@ EOF
 # to enable python pylint_odoo checks into the vim editor.
 cat >> /root/.vimrc << EOF
 :filetype on
-let g:syntastic_python_checkers = ['pylint']
+let g:syntastic_aggregate_errors = 1
+let g:syntastic_python_checkers = ['pylint', 'flake8']
+let g:syntastic_auto_loc_list = 1
 let g:syntastic_python_pylint_args =
-    \ '--load-plugins=pylint_odoo -e odoolint'
-function! FindConfig(prefix, what, where)
-    let cfg = findfile(a:what, escape(a:where, ' ') . ';')
-    return cfg !=# '' ? ' ' . a:prefix . ' ' . cfg : ''
-endfunction
-
-autocmd FileType python let b:syntastic_python_pylint_args =
-    \ get(g:, 'syntastic_python_pylint_args', '') .
-    \ FindConfig('-c', 'pylint_vauxoo_light_pr.cfg', expand('<amatch>:p:h', 1))
+    \ '--rcfile=/.repo_requirements/linit_hook/travis/cfg/travis_run_pylint_vim.cfg --load-plugins=pylint_odoo'
+let g:syntastic_python_flake8_args =
+    \ '--config=/.repo_requirements/linit_hook/travis/cfg/travis_run_flake8.cfg'
 EOF
 
 cat >> /root/.vimrc.bundles << EOF

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -137,17 +137,17 @@ EOF
 # Configure pylint_odoo plugin and the .conf file
 # to enable python pylint_odoo checks into the vim editor.
 cat >> /root/.vimrc << EOF
-:filetype on                                                                    
-let g:syntastic_python_checkers = ['pylint']                                    
-let g:syntastic_python_pylint_args =                                            
-    \ '--load-plugins=pylint_odoo -e odoolint'                                  
-function! FindConfig(prefix, what, where)                                       
-    let cfg = findfile(a:what, escape(a:where, ' ') . ';')                      
-    return cfg !=# '' ? ' ' . a:prefix . ' ' . cfg : ''                         
-endfunction                                                                     
-                                                                                
-autocmd FileType python let b:syntastic_python_pylint_args =                    
-    \ get(g:, 'syntastic_python_pylint_args', '') .                             
+:filetype on
+let g:syntastic_python_checkers = ['pylint']
+let g:syntastic_python_pylint_args =
+    \ '--load-plugins=pylint_odoo -e odoolint'
+function! FindConfig(prefix, what, where)
+    let cfg = findfile(a:what, escape(a:where, ' ') . ';')
+    return cfg !=# '' ? ' ' . a:prefix . ' ' . cfg : ''
+endfunction
+
+autocmd FileType python let b:syntastic_python_pylint_args =
+    \ get(g:, 'syntastic_python_pylint_args', '') .
     \ FindConfig('-c', 'pylint_vauxoo_light_pr.cfg', expand('<amatch>:p:h', 1))
 EOF
 


### PR DESCRIPTION
…m editor using the configuration file

# [VX#5691] (https://www.vauxoo.com/web#id=5691&view_type=form&model=project.task&menu_id=136&action=138)

- [x] Fix #140 

This PR is to activate only the python `pylint_odoo` checks with the .conf file.

The result has to see like this:
![vim-sql-injection-error](https://cloud.githubusercontent.com/assets/11741384/16822701/f6e21ee0-4923-11e6-8562-0bcaa08f40d4.png) 