### PR TITLE
[ADD] docker-odoo-image: Fix #144 installing py3.x versions to allow …

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -75,15 +75,15 @@ NPM_DEPENDS="localtunnel \
 
 # Let's add the git-core ppa for having a more up-to-date git
 add_custom_aptsource "${GITCORE_PPA_REPO}" "${GITCORE_PPA_KEY}"
+# Add python repository
+add-apt-repository ppa:${PPA_SOURCES}
 
 # Release the apt monster!
 apt-get update
 apt-get upgrade
-apt-get install -y ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
-# Add python repository and install py 3.x
-add-apt-repository -y ppa:${PPA_SOURCES}
-apt-get update
-apt-get install -y ${DPKG_PYTHON_VERS}
+apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
+# Install py 3.x
+apt-get install ${DPKG_PYTHON_VERS}
 
 # Install node dependencies
 npm install ${NPM_OPTS} ${NPM_DEPENDS}

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -16,7 +16,8 @@ GITCORE_PPA_REPO="deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main"
 GITCORE_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xA1715D88E1DF1F24"
 
 # ppa sources
-PPA_SOURCES="fkrull/deadsnakes"
+PYTHON_PPA_REPO="deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main"
+PYTHON_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x5BB92C09DB82666C"
 
 # Extra software download URLs
 HUB_ARCHIVE="https://github.com/github/hub/releases/download/v2.2.3/hub-linux-${ARCH}-2.2.3.tgz"
@@ -43,9 +44,8 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               expect-dev mosh bpython bsdtar rsync \
               ghostscript graphviz openssh-server zsh \
               lua50 liblua50-dev liblualib50-dev \
-              exuberant-ctags git rake software-properties-common \
-              python-software-properties"
-DPKG_PYTHON_VERS="python3.3 python3.4 python3.5"
+              exuberant-ctags git rake python3.3 python3.4 \
+              python3.5"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="SOAPpy pyopenssl suds \
@@ -75,15 +75,14 @@ NPM_DEPENDS="localtunnel \
 
 # Let's add the git-core ppa for having a more up-to-date git
 add_custom_aptsource "${GITCORE_PPA_REPO}" "${GITCORE_PPA_KEY}"
-# Add python repository
-add-apt-repository ppa:${PPA_SOURCES}
+# Let's add the fkrull deadsnakes ppa for get python3.x versions
+add_custom_aptsource "${PYTHON_PPA_REPO}" "${PYTHON_PPA_KEY}"
+
 
 # Release the apt monster!
 apt-get update
 apt-get upgrade
 apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
-# Install py 3.x
-apt-get install ${DPKG_PYTHON_VERS}
 
 # Install node dependencies
 npm install ${NPM_OPTS} ${NPM_DEPENDS}

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -15,6 +15,9 @@ ARCH="$( dpkg --print-architecture )"
 GITCORE_PPA_REPO="deb http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main"
 GITCORE_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xA1715D88E1DF1F24"
 
+# ppa sources
+PPA_SOURCES="fkrull/deadsnakes"
+
 # Extra software download URLs
 HUB_ARCHIVE="https://github.com/github/hub/releases/download/v2.2.3/hub-linux-${ARCH}-2.2.3.tgz"
 NGROK_ARCHIVE="https://dl.ngrok.com/ngrok_2.0.19_linux_${ARCH}.zip"
@@ -40,7 +43,9 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               expect-dev mosh bpython bsdtar rsync \
               ghostscript graphviz openssh-server zsh \
               lua50 liblua50-dev liblualib50-dev \
-              exuberant-ctags git rake"
+              exuberant-ctags git rake software-properties-common \
+              python-software-properties"
+DPKG_PYTHON_VERS="python3.3 python3.4 python3.5"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="SOAPpy pyopenssl suds \
@@ -74,7 +79,11 @@ add_custom_aptsource "${GITCORE_PPA_REPO}" "${GITCORE_PPA_KEY}"
 # Release the apt monster!
 apt-get update
 apt-get upgrade
-apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
+apt-get install -y ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
+# Add python repository and install py 3.x
+add-apt-repository -y ppa:${PPA_SOURCES}
+apt-get update
+apt-get install -y ${DPKG_PYTHON_VERS}
 
 # Install node dependencies
 npm install ${NPM_OPTS} ${NPM_DEPENDS}


### PR DESCRIPTION
…the correctly use of tox

## [VX#5703 ] (https://www.vauxoo.com/web#id=5703&view_type=form&model=project.task&menu_id=136&action=138)

**ToDo:**
- [x] Include the commands of the following [gist] (https://gist.github.com/moylop260/e7b14b4a205e40cdcafc4d729309fb7e) into the `build-image.sh` file
- [x] Make a local docker-odoo-image to test the changes building a new project image with t2d.
  - [x] Make the test with the following commands:
```bash
pip install tox
git clone git@github.com:PyCQA/pylint.git
cd pylint
tox -e py27,py33,py34,py35
```
- [x] Add screenshot with the results.

**Results**

![tox-e-py-3-x](https://cloud.githubusercontent.com/assets/11741384/16960662/1ec73d74-4db0-11e6-84d5-8b6bad89cbd8.png)


![py-versions](https://cloud.githubusercontent.com/assets/11741384/16961257/4b655aa8-4db2-11e6-99e1-2f1708ae2a50.png)

