### PR TITLE
[IMP] docker-odoo-image: Install pip3 for python3.x versions

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -45,7 +45,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               ghostscript graphviz openssh-server zsh \
               lua50 liblua50-dev liblualib50-dev \
               exuberant-ctags git rake python3.3 python3.4 \
-              python3.5"
+              python3.5 python3-pip"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="SOAPpy pyopenssl suds \


### PR DESCRIPTION
## [VX#5712] (https://www.vauxoo.com/web#id=5712&view_type=form&model=project.task&menu_id=136&action=138)

ToDo:
- [x] Install pip3 for python3.x versions.
- [x] Prove it with the following command, e.g.,
`python3.3 -m pip --version`
- [x] Add screenshots.

![pip3-version](https://cloud.githubusercontent.com/assets/11741384/17035412/be286224-4f4c-11e6-9ff9-6f3214230d8e.png)

![pip3-python3-x-versions](https://cloud.githubusercontent.com/assets/11741384/17038452/63bfcdea-4f5b-11e6-9615-e1a5790654cb.png)

