### PR TITLE
[IMP] docker-odoo-image: Install required libraries to facilitate the…

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -53,7 +53,8 @@ PIP_DEPENDS_EXTRA="SOAPpy pyopenssl suds \
                    recaptcha-client egenix-mx-base \
                    PyWebDAV mygengo pandas numexpr \
                    ndg-httpsclient pyasn1 line-profiler \
-                   watchdog isort coveralls diff-highlight"
+                   watchdog isort coveralls diff-highlight \
+                   argcomplete"
 PIP_DPKG_BUILD_DEPENDS="build-essential \
                         gfortran \
                         cython \


### PR DESCRIPTION
… use of odoo-instance and other scripts
## [VX#5714](https://www.vauxoo.com/web#id=5714&view_type=form&model=project.task&menu_id=136&action=138)

**ToDo:**
- [x] Install `argcomplete` in order to use the `odoo-instance` script and others in `gist-vauxoo` that require this library.
- [x] Ask for the other missing libraries found in another scripts.

``` bash
meta
oerplib
launchpad
launchpadlib
premailer
bs4
```
