### PR TITLE
[REF] odoo-shippable: Install X server "Xvfb"

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -47,7 +47,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               lua50 liblua50-dev liblualib50-dev \
               exuberant-ctags git rake python3.3 python3.3-dev \
               python3.4 python3.4-dev python3.5 python3.5-dev \
-              python3-pip software-properties-common"
+              python3-pip software-properties-common Xvfb"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="SOAPpy pyopenssl suds \


### PR DESCRIPTION
The travis image quay.io/travisci/travis-python has installed the package `xvfb`
docker run -it --rm quay.io/travisci/travis-python /bin/sh -c "which Xvfb"
Output: `/usr/bin/Xvfb`

[OCA recommend us use a x server](https://github.com/OCA/maintainer-quality-tools/blob/14aa6f677f16b8fe13eb0467f5cae277a656acd7/sample_files/.travis.yml#L28-L31) in order to avoid issues using webkit (wkhtmltopdf)