### PR TITLE
[FIX] Fixed missing package in Odoo 8.0 base image

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -43,7 +43,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               xsltproc xmlstarlet openssl \
               poppler-utils antiword p7zip-full \
               expect-dev mosh bpython bsdtar rsync \
-              ghostscript graphviz openssh-server zsh \
+              graphviz openssh-server zsh \
               lua50 liblua50-dev liblualib50-dev \
               exuberant-ctags git rake python3.3 python3.3-dev \
               python3.4 python3.4-dev python3.5 python3.5-dev \

--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -44,7 +44,8 @@ DPKG_DEPENDS="nodejs \
               libxslt1-dev \
               libgeoip-dev \
               cython \
-              fontconfig"
+              fontconfig \
+              ghostscript"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \


### PR DESCRIPTION
This fixes an issue reported by @luistorresm [here](https://www.vauxoo.com/web?db=vauxoo#id=5955&view_type=form&model=project.task)  where the fonts were showing different in runbot and dev  instances.

The lack of the installed package doesn't show any error, just seems to install an additional font / font-family.

The odoo80 image now:
![a](http://screenshots.vauxoo.com/tulio/14230626316-SUC3ukxjqC.jpg)

@moylop260 I think we should move all packages actually required by Odoo to the base image and install those required to test and dev only in the shippable image, because we end with different environments. IMHO we should have at least the same base for prod, dev and test to avoid this issues in the future. What do you think?

