### PR TITLE
[FIX] Error with ngrok not being installed

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -21,7 +21,7 @@ PYTHON_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x5BB
 
 # Extra software download URLs
 HUB_ARCHIVE="https://github.com/github/hub/releases/download/v2.2.3/hub-linux-${ARCH}-2.2.3.tgz"
-NGROK_ARCHIVE="https://dl.ngrok.com/ngrok_2.0.19_linux_${ARCH}.zip"
+NGROK_ARCHIVE="https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-${ARCH}.zip"
 
 # Extra software clone URLs
 ZSH_THEME_REPO="https://gist.github.com/9931af23bbb59e772eec.git"


### PR DESCRIPTION
@moylop260 I was getting this error in quay.io:

![a](http://screenshots.vauxoo.com/tulio/19480126316-RRlnuECG0e.jpg)

It seems that the download url for ngrok have changed:
![b](http://screenshots.vauxoo.com/tulio/19491226316-4BEE3sLMrD.jpg)

And from the site you can see that they're using this now: https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip

So I updated the build script to use this new one, now it is installed properly:

![c](http://screenshots.vauxoo.com/tulio/19551726316-XDuMIThaN9.jpg)