### PR TITLE
[REF] odoo-shippable: Change execution permission

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -130,6 +130,7 @@ LINT_CHECK=1 TESTS=0 ${REPO_REQUIREMENTS}/linit_hook/travis/travis_install_night
 # Install hub & ngrok
 targz_download_execute "${HUB_ARCHIVE}" "install"
 zip_download_copy "${NGROK_ARCHIVE}" "ngrok" "/usr/local/bin/"
+chmod +x /usr/local/bin/ngrok
 
 # Configure diff-highlight on git after install
 cat >> /etc/gitconfig << EOF


### PR DESCRIPTION
Fix error: `/usr/local/bin/ngrok: permission denied.`

Steps to reproduce it:
`docker run --rm vauxoo/odoo-80-image-shippable-auto /usr/local/bin/ngrok --version`
`docker: Error response from daemon: oci runtime error: exec: "/usr/local/bin/ngrok": permission denied.`

Continuation of https://github.com/Vauxoo/docker-odoo-image/pull/157