### PR TITLE
[REF] odoo80: Remove manual installation of pandas

### DIFF
--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -62,7 +62,6 @@ PIP_DEPENDS_EXTRA="pyyaml \
                    SOAPpy \
                    suds \
                    lxml \
-                   pandas \
                    qrcode \
                    xmltodict \
                    flake8 \


### PR DESCRIPTION
Because is installed from addons-vauxoo requirements.txt in version required.

This PR avoid re-install the pandas packages in each t2d or production script.
![screen shot 2016-11-09 at 5 47 44 pm](https://cloud.githubusercontent.com/assets/6644187/20159202/d39f207a-a6a4-11e6-8336-d5de58e64636.png)
