### PR TITLE
[ADD] Add RVM support

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -262,6 +262,17 @@ psql_create_role "root" "aeK5NWNr2"
 # Enable PG LOGS AND NON DURABILITY
 PG_NON_DURABILITY=1 PG_LOGS_ENABLE=1 python ${REPO_REQUIREMENTS}/linit_hook/travis/psql_log.py
 
+# Install & Configure RVM
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+\curl -sSL https://get.rvm.io | /bin/bash -s stable --ruby
+
+cat >> /etc/bash.bashrc << EOF
+
+# Load RVM into a shell session *as a function*
+source "/usr/local/rvm/scripts/rvm"
+
+EOF
+
 # Final cleaning
 rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf


### PR DESCRIPTION
This adds RVM support to the Odoo docker image. 

* Add mpapis public key
* Install RVM & configure shell

The problem is that this still doesn't work on its own, and requires the following change in T2D- https://github.com/Vauxoo/travis2docker/compare/master...laslabs:feature/add-rvm?expand=1

It seems that the bash profile is not being sourced during the `before_install`, even if I explicitly do `RUN /bin/bash -c "/before_install /install"`. An error about RVM not being available is output when running the aforementioned.

Along the same lines, it is not being sourced during entrypoint execution either. In this case, the gems that were installed in RVM are not available to the build.

The best part about this is that if I open an interactive shell to the container, RVM works fine:

```
# docker run -i -t laslabs/docker-odoo-image:feature_add-rvm
[root@8fdb4e1b6891]/$
$ rvm -v
rvm 1.27.0 (latest) by Wayne E. Seguin <wayneeseguin@gmail.com>, Michal Papis <mpapis@gmail.com> [https://rvm.io/]
```

I've tried a metric ton of things, and have now given up. Following is a list of things that should have worked, but didn't:

* Symlink `bash` on top of `sh` under the possibility that something was running under incorrect shell
* Append contents of `/etc/bash.bashrc` to `/etc/profile` under possibility that something is using an interactive login shell
* Add conditionals to handle RVM sourcing for non-root user under possibility that there is some non-root user that I don't see running something
* Manually modify the path in bash profile under possibility that RVM source was being overridden by another path modification
* `RUN /bin/bash --rcfile /etc/bash.bashrc -c "/before_install /install"` because I was out of other ideas

My conclusion is that I hate RVM. If you have any other ideas I'm all ears. Otherwise I'll submit the T2D PR as well, then proceed to the bar to drink away the sorrows.

Re OCA/website#284