### PR TITLE
[IMP] Avoid ssh access w/ password and block root ssh access (nor pass neither ssh-key)

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -75,6 +75,8 @@ pip install ${PIP_OPTS} ${PIP_DEPENDS_EXTRA}
 wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/cookbooks/travis_build_environment/files/default/etc-init.d-xvfb.sh -O /etc/init.d/xvfb
 chmod +x /etc/init.d/xvfb
 
+# Configure ssh server to not allow root and force ssh login to all other users
+configure_sshd
 # Init without download to add odoo remotes
 git init ${REPO_REQUIREMENTS}/odoo
 git --git-dir="${REPO_REQUIREMENTS}/odoo/.git" remote add vauxoo "${ODOO_VAUXOO_REPO}"

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -75,8 +75,6 @@ pip install ${PIP_OPTS} ${PIP_DEPENDS_EXTRA}
 wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/cookbooks/travis_build_environment/files/default/etc-init.d-xvfb.sh -O /etc/init.d/xvfb
 chmod +x /etc/init.d/xvfb
 
-# Configure ssh server to not allow root and force ssh login to all other users
-configure_sshd
 # Init without download to add odoo remotes
 git init ${REPO_REQUIREMENTS}/odoo
 git --git-dir="${REPO_REQUIREMENTS}/odoo/.git" remote add vauxoo "${ODOO_VAUXOO_REPO}"
@@ -221,8 +219,11 @@ EOF
 echo $'#!/bin/bash\n$@' > /usr/bin/travis_wait
 chmod +x /usr/bin/travis_wait
 
-# Configure ssh to allow root login
-echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+# Configure ssh to allow root login but just using ssh key
+cat >> /etc/ssh/sshd_config << EOF
+PermitRootLogin yes
+PasswordAuthentication no
+EOF
 
 # Extend root config to every user created from now on
 ln -sf /root/.profile /root/.bash* /root/.vim* /etc/skel/

--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -63,3 +63,11 @@ createuser(){
 psql_create_role(){
     su - postgres -c "psql -c  \"CREATE ROLE ${1} LOGIN PASSWORD '${2}' SUPERUSER INHERIT CREATEDB CREATEROLE;\""
 }
+
+configure_sshd(){
+    cat >> /etc/ssh/sshd_config << EOF
+PermitRootLogin no
+DenyUsers root
+PasswordAuthentication no
+EOF
+}

--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -63,11 +63,3 @@ createuser(){
 psql_create_role(){
     su - postgres -c "psql -c  \"CREATE ROLE ${1} LOGIN PASSWORD '${2}' SUPERUSER INHERIT CREATEDB CREATEROLE;\""
 }
-
-configure_sshd(){
-    cat >> /etc/ssh/sshd_config << EOF
-PermitRootLogin no
-DenyUsers root
-PasswordAuthentication no
-EOF
-}


### PR DESCRIPTION
@moylop260 with this you avoid to be asked for the password when try to ssh a server:

Try so ssh  with root:

![a](http://screenshots.vauxoo.com/tulio/21440533216-cuNqh7NgvW.jpg)

And also tested adding a key to the root user:

![c](http://screenshots.vauxoo.com/tulio/21464333216-cDe8f5aDvU.jpg)

Then added the root key to the shippable use to be sure we can connect:

![d](http://screenshots.vauxoo.com/tulio/21484433216-jtUz7MjOPw.jpg)

With shippable (no added key):

![b](http://screenshots.vauxoo.com/tulio/21445633216-78XTvf7fuR.jpg)

The users can be added using ```https://github.com/<username>.keys```, with this you can keys the .pub keys the user have registered in github if you know the username, I tried with different formats for git log but only could get the actual registered name:

![e](http://screenshots.vauxoo.com/tulio/21514733216-C9brDdz06j.jpg)

We have used it a few times, but in some way we have the user login, in [Orchest](https://git.vauxoo.com/vauxoo/deployv/blob/master/deployv/instance/instancev.py#L162) for example and in the Ansible files used to install the servers:

![f](http://screenshots.vauxoo.com/tulio/22032133216-DQUpTIfq07.jpg)

