### PR TITLE
[FIX] odoo-shippable: Fix pypa/setuptools#942

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -49,7 +49,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
               python3-pip software-properties-common Xvfb libmagickwand-dev"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
-PIP_DEPENDS_EXTRA="line-profiler watchdog isort coveralls diff-highlight pg-activity virtualenv"
+PIP_DEPENDS_EXTRA="line-profiler watchdog isort coveralls diff-highlight pg-activity virtualenv setuptools==33.1.1"
 PIP_DPKG_BUILD_DEPENDS=""
 NPM_OPTS="-g"
 NPM_DEPENDS="localtunnel fs-extra eslint"

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -111,7 +111,7 @@ ln -sf ${REPO_REQUIREMENTS}/linit_hook/git/* /usr/share/git-core/templates/hooks
 
 # Execute travis_install_nightly
 LINT_CHECK=1 TESTS=0 ${REPO_REQUIREMENTS}/linit_hook/travis/travis_install_nightly
-pip install --user -q --no-binary pycparser -r ${REPO_REQUIREMENTS}/linit_hook/travis/requirements.txt
+pip install --no-binary pycparser -r ${REPO_REQUIREMENTS}/linit_hook/travis/requirements.txt
 
 # Install hub & ngrok
 targz_download_execute "${HUB_ARCHIVE}" "install"


### PR DESCRIPTION
Avoid the following traceback:
```bash
Generated script '/home/user/plone/zinstance/bin/buildout'.
Traceback (most recent call last):
  File "bin/buildout", line 13, in <module>
    import zc.buildout.buildout
  File "/home/user/.buildout/eggs/zc.buildout-2.5.3-py2.7.egg/zc/buildout/buildout.py", line 18, in <module>
    import zc.buildout.easy_install
  File "/home/user/.buildout/eggs/zc.buildout-2.5.3-py2.7.egg/zc/buildout/easy_install.py", line 26, in <module>
    import pkg_resources
  File "/home/user/.buildout/eggs/setuptools-34.0.1-py2.7.egg/pkg_resources/__init__.py", line 72, in <module>
    import packaging.requirements
  File "/home/user/.buildout/eggs/packaging-16.8-py2.7.egg/packaging/requirements.py", line 59, in <module>
    MARKER_EXPR = originalTextFor(MARKER_EXPR())("marker")
TypeError: __call__() takes exactly 2 arguments (1 given)
```