### PR TITLE
[FIX] odoo80: Fix pypa/setuptools#942

### DIFF
--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -75,7 +75,8 @@ PIP_DEPENDS_EXTRA="pyyaml \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
                    git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
-                   requirements-parser==0.1.0"
+                   requirements-parser==0.1.0 \
+                   setuptools==33.1.1"
 
 PIP_DPKG_BUILD_DEPENDS=""
 

--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -93,6 +93,7 @@ npm install ${NPM_OPTS} ${NPM_DEPENDS}
 
 # Let's recursively find our pip dependencies
 collect_pip_dependencies "${ODOO_DEPENDENCIES}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
+echo "setuptools==33.1.1" >> ${DEPENDENCIES_FILE}
 
 # Install python dependencies
 pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}


### PR DESCRIPTION
Avoid the following traceback:
```bash
Generated script '/home/user/plone/zinstance/bin/buildout'.
Traceback (most recent call last):
  File "bin/buildout", line 13, in <module>
    import zc.buildout.buildout
  File "/home/user/.buildout/eggs/zc.buildout-2.5.3-py2.7.egg/zc/buildout/buildout.py", line 18, in <module>
    import zc.buildout.easy_install
  File "/home/user/.buildout/eggs/zc.buildout-2.5.3-py2.7.egg/zc/buildout/easy_install.py", line 26, in <module>
    import pkg_resources
  File "/home/user/.buildout/eggs/setuptools-34.0.1-py2.7.egg/pkg_resources/__init__.py", line 72, in <module>
    import packaging.requirements
  File "/home/user/.buildout/eggs/packaging-16.8-py2.7.egg/packaging/requirements.py", line 59, in <module>
    MARKER_EXPR = originalTextFor(MARKER_EXPR())("marker")
TypeError: __call__() takes exactly 2 arguments (1 given)
```

Similar to https://github.com/Vauxoo/docker-odoo-image/pull/189