### PR TITLE
Revert "Install coverage in the virtual environment"

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -115,13 +115,6 @@ virtualenv --system-site-packages ${REPO_REQUIREMENTS}/virtualenv/python2.7
 nodeenv ${REPO_REQUIREMENTS}/virtualenv/nodejs
 echo "REPO_REQUIREMENTS=${REPO_REQUIREMENTS}" >> /etc/bash.bashrc
 
-# Install coverage in the virtual environment
-source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate
-pip install --force-reinstall --upgrade coverage --src .
-deactivate
-
-ln -sfv ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/coverage /usr/local/bin/coverage
-
 # Execute travis_install_nightly
 LINT_CHECK=1 TESTS=0 ${REPO_REQUIREMENTS}/linit_hook/travis/travis_install_nightly
 pip install --no-binary pycparser -r ${REPO_REQUIREMENTS}/linit_hook/travis/requirements.txt


### PR DESCRIPTION
Reverts Vauxoo/docker-odoo-image#201

After https://github.com/Vauxoo/travis2docker/pull/95
I think that the change of coverage venv is not required