### PR TITLE
[REF] odoo-shippable: Install pstats_print2list required cache packages

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -49,7 +49,9 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
               python3-pip software-properties-common Xvfb libmagickwand-dev"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
-PIP_DEPENDS_EXTRA="line-profiler watchdog isort coveralls diff-highlight pg-activity virtualenv setuptools==33.1.1 nodeenv"
+PIP_DEPENDS_EXTRA="line-profiler watchdog isort coveralls diff-highlight \
+                   pg-activity virtualenv setuptools==33.1.1 nodeenv \
+                   pstats_print2list"
 PIP_DPKG_BUILD_DEPENDS=""
 NPM_OPTS="-g"
 NPM_DEPENDS="localtunnel fs-extra eslint"


### PR DESCRIPTION
The section where is installed is not executed from [travis_install_nightly#L116](https://github.com/Vauxoo/maintainer-quality-tools/blob/832682c0b783b238722378d199474a86f5109f96/travis/travis_install_nightly#L116) script called. 
Fix [vauxoo/instance#348](https://git.vauxoo.com/vauxoo/instance/issues/348)