### PR TITLE
Add improvement to start ssh service from user odoo

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -366,6 +366,15 @@ sed -i 's/#max_pred_locks_per_transaction = 64/max_pred_locks_per_transaction = 
 sed -i 's/max_connections = 100/max_connections = 200/g' /etc/postgresql/*/main*/postgresql.conf
 sed -i 's/^port = .*/port = 5432/g' /etc/postgresql/*/main*/postgresql.conf
 
+# Configure ssh service to be started by user odoo
+setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/sshd
+chown  odoo:odoo /etc/ssh/ssh_host_*
+mkdir /var/run/sshd
+sed -i "s/\/var\/run\/sshd.pid/\/tmp\/sshd.pid/g" /etc/init.d/ssh
+cat >> /etc/ssh/sshd_config << EOF
+PidFile /tmp/sshd.pid
+EOF
+
 # Overwrite get_versions function to avoid overwriting the init script
 # See https://github.com/vauxoo/docker-odoo-image/issues/114 for details
 cat >> /usr/share/postgresql-common/init.d-functions << 'EOF'

--- a/odoo-shippable/scripts/entrypoint_image
+++ b/odoo-shippable/scripts/entrypoint_image
@@ -66,7 +66,7 @@ def docker_entrypoint():
             subprocess.call(cmd, shell=True)
 
     # Start ssh service
-    if os.environ.get('START_SSH', False) and pwd.getpwuid(os.getuid())[0] == 'root':
+    if os.environ.get('START_SSH', False):
         cmd = "/etc/init.d/ssh start"
         subprocess.call(cmd, shell=True)
 


### PR DESCRIPTION
Before
![before](https://cloud.githubusercontent.com/assets/16363083/23824798/b596e0b8-0653-11e7-94f9-e8079d947614.png)
After
![after](https://cloud.githubusercontent.com/assets/16363083/23824959/3bd21ffa-0657-11e7-949b-d8ed9ae4f085.png)



TODO

1. Used setcap to allow binary /usr/sbin/sshd access to low number ports
2. Change permissions on keys and change the path of the file where the process id (pidfile) is stored (/var/run/sshd.pid by /tmp/sshd.pid) to correct problems with permissions
