### PR TITLE
[IMP] Adding script for detecting snippet repeated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo80 --docker-image vauxoo/odoo-80-image:latest
   - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo-shippable --docker-image vauxoo/odoo-80-image-shippable-auto:latest
   - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo100 --docker-image vauxoo/odoo-100-image:latest
+  - docker run -it --rm --name fix-vim-snippet -v ${TRAVIS_BUILD_DIR}/odoo-shippable/scripts/fix-vim-snippet.py:/root/fix-vim-snippet.py vauxoo/odoo-80-image-shippable-auto python /root/fix-vim-snippet.py --extensions sh,sql,python
 
 after_success:
     # TODO: Add docker push

--- a/odoo-shippable/scripts/fix-vim-snippet.py
+++ b/odoo-shippable/scripts/fix-vim-snippet.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import glob
 import argparse
 import linecache
@@ -15,7 +16,6 @@ class FixVimSnippet(object):
         self.snippet = {}
         self.extension_snippet = {}
         self.repeated_snippet = {}
-        self._fix()
 
     def _add_extension_snippet(self, extension, name_snippet, data):
         self.extension_snippet[extension].setdefault(name_snippet, [])
@@ -25,9 +25,9 @@ class FixVimSnippet(object):
                 return
         self.extension_snippet[extension][name_snippet].append(data)
 
-    def _fix(self):
+    def fix(self):
         if not os.path.isdir(self.bundle_dir):
-            return
+            return 1
         module = None
         for path in glob.glob(self.bundle_dir + '/*/*/*.snippets'):
             module, folder, file_name = (os.path.relpath(
@@ -90,6 +90,7 @@ class FixVimSnippet(object):
                             'begin_line': begin_line,
                             'end_line': line}
                     self._add_extension_snippet(extension, name_snippet, data)
+        return_value = 0
         for extension, snippets in self.extension_snippet.items():
             for name, snippet in snippets.items():
                 if len(snippet) == 1:
@@ -118,11 +119,13 @@ class FixVimSnippet(object):
                              duplicate['end_line'])
                 output+="\n+++++"
                 if has_repeated:
+                    return_value = 1
                     print output
+        return return_value
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--extensions', dest='extensions', default=[],
                         help='Extensions you will be looking for')
-    FixVimSnippet(parser.parse_args().extensions)
+    sys.exit(FixVimSnippet(parser.parse_args().extensions).fix())

--- a/odoo-shippable/scripts/fix-vim-snippet.py
+++ b/odoo-shippable/scripts/fix-vim-snippet.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+import os
+import glob
+import argparse
+
+
+class FixVimSnippet(object):
+
+    def __init__(self, extensions):
+        self.extensions = extensions
+        self.bundle_dir = os.path.join(os.environ.get('HOME'), '.vim',
+                                       'bundle')
+        self.snippet = {}
+        self.extension_snippet = {}
+        self.repeated_snippet = {}
+        self._fix()
+
+    def _fix(self):
+        if os.path.isdir(self.bundle_dir):
+            module = None
+            for path in glob.glob(self.bundle_dir + '/*/*/*.snippets'):
+                module, folder, file_name = (path.replace(
+                    self.bundle_dir + os.sep, '').split(os.sep))
+                name, extension = os.path.splitext(file_name)
+                if self.extensions and not name in self.extensions:
+                    continue
+                if not self.snippet.has_key(name):
+                    self.snippet[name] = []
+                self.snippet[name].append({'snippet': file_name,
+                                           'module': module,
+                                           'folder': folder,
+                                           'path': path})
+            for extension, snippets in self.snippet.iteritems():
+                if len(snippets) > 1:
+                    for snippet in snippets:
+                        if not self.extension_snippet.has_key(extension):
+                            self.extension_snippet[extension] = {}
+                        path = snippet['path']
+                        with open(path) as _file:
+                            _snippets = [item.strip() for item in
+                                         _file.readlines()]
+                            line = 0
+                            total_lines = len(_snippets)
+                            name_snippet = None
+                            begin_line = None
+                            end_line = None
+                            for _snippet in _snippets:
+                                line += 1
+                                if _snippet.startswith('snippet'):
+                                    try:
+                                        name_snippet = _snippet.split(" ")[1]
+                                    except Exception:
+                                        continue
+                                    begin_line = line
+                                    end_line = None
+                                elif _snippet.startswith('endsnippet'):
+                                    end_line = line
+                                else:
+                                    _next = _snippets[(line - 1) +
+                                                      (0 if (line + 1) >=
+                                                       total_lines else 1)]
+                                    if (_next.startswith('snippet') or
+                                            (line == total_lines)):
+                                        end_line = line
+                                if name_snippet and end_line and begin_line:
+                                    if (not self.extension_snippet[extension]
+                                            .has_key(name_snippet)):
+                                        self.extension_snippet[extension]\
+                                            [name_snippet] = []
+                                    self.extension_snippet[extension]\
+                                        [name_snippet].append({
+                                            'path': path,
+                                            'name_snippet': name_snippet,
+                                            'begin_line': begin_line,
+                                            'end_line': end_line
+                                    })
+                                    name_snippet = None
+                                    begin_line = None
+                                    end_line = None
+            for extension in self.extension_snippet:
+                for snippet in self.extension_snippet[extension]:
+                    if len(self.extension_snippet[extension][snippet]) > 1:
+                        original = self.extension_snippet[extension]\
+                            [snippet][0]
+                        print "Snippet repeated for '%s' named '%s'" % (
+                            extension, snippet)
+                        print "First defined in %s line(%s:%s)" % (
+                            original['path'], original['begin_line'],
+                            original['end_line'])
+                        print "+++++"
+                        repeated = self.extension_snippet[extension][snippet][1:]
+                        for _snippet in repeated:
+                            print "Snippet defined in %s line(%s:%s)" %(
+                                _snippet['path'], _snippet['begin_line'],
+                                 _snippet['end_line'])
+                        print "+++++"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--extensions', dest='extensions', default=[],
+                        help='Extensions you will be looking for')
+    FixVimSnippet(parser.parse_args().extensions)

--- a/odoo-shippable/scripts/fix-vim-snippet.py
+++ b/odoo-shippable/scripts/fix-vim-snippet.py
@@ -19,6 +19,10 @@ class FixVimSnippet(object):
 
     def _add_extension_snippet(self, extension, name_snippet, data):
         self.extension_snippet[extension].setdefault(name_snippet, [])
+        for snippet in self.extension_snippet[extension][name_snippet]:
+            if (data['path'] == snippet['path'] and
+                    data['name_snippet'] == snippet['name_snippet']):
+                return
         self.extension_snippet[extension][name_snippet].append(data)
 
     def _fix(self):
@@ -50,7 +54,12 @@ class FixVimSnippet(object):
                     line += 1
                     if line_file.startswith('snippet'):
                         try:
-                            name_snippet = line_file.split(" ")[1]
+                            line_split = line_file.split(" ")
+                            name_snippet = line_split[1]
+                            if (not all(item not in ('<', '>', '<=', '>=',
+                                                     '==') for item in
+                                        line_split[2:])):
+                                continue
                         except Exception:
                             continue
                         begin_line = line

--- a/odoo-shippable/scripts/fix-vim-snippet.py
+++ b/odoo-shippable/scripts/fix-vim-snippet.py
@@ -22,80 +22,78 @@ class FixVimSnippet(object):
         self.extension_snippet[extension][name_snippet].append(data)
 
     def _fix(self):
-        if os.path.isdir(self.bundle_dir):
-            module = None
-            for path in glob.glob(self.bundle_dir + '/*/*/*.snippets'):
-                module, folder, file_name = (os.path.relpath(
+        if not os.path.isdir(self.bundle_dir):
+            return
+        module = None
+        for path in glob.glob(self.bundle_dir + '/*/*/*.snippets'):
+            module, folder, file_name = (os.path.relpath(
                     path, self.bundle_dir).split(os.sep))
-                name, extension = os.path.splitext(file_name)
-                if self.extensions and name not in self.extensions:
-                    continue
-                self.snippet.setdefault(name, []).append({'snippet': file_name,
-                                                          'module': module,
-                                                          'folder': folder,
-                                                          'path': path})
-            for extension, snippets in self.snippet.items():
-                if len(snippets) == 1:
-                    continue
-                self.extension_snippet.setdefault(extension, {})
-                for snippet in snippets:
-                    path = snippet['path']
-                    line = 0
-                    name_snippet = None
-                    begin_line = None
-                    end_line = None
-                    for line_file in open(path):
-                        line_file = line_file.strip()
-                        line += 1
-                        if line_file.startswith('snippet'):
-                            try:
-                                name_snippet = line_file.split(" ")[1]
-                            except Exception:
-                                continue
-                            begin_line = line
-                            end_line = None
-                        elif line_file.startswith('endsnippet'):
+            name, extension = os.path.splitext(file_name)
+            if self.extensions and name not in self.extensions:
+                continue
+            self.snippet.setdefault(name, []).append({'snippet': file_name,
+                                                      'module': module,
+                                                      'folder': folder,
+                                                      'path': path})
+        for extension, snippets in self.snippet.items():
+            if len(snippets) == 1:
+                continue
+            self.extension_snippet.setdefault(extension, {})
+            for snippet in snippets:
+                path = snippet['path']
+                line = 0
+                name_snippet = None
+                begin_line = None
+                end_line = None
+                for line_file in open(path):
+                    line_file = line_file.strip()
+                    line += 1
+                    if line_file.startswith('snippet'):
+                        try:
+                            name_snippet = line_file.split(" ")[1]
+                        except Exception:
+                            continue
+                        begin_line = line
+                        end_line = None
+                    elif line_file.startswith('endsnippet'):
+                        end_line = line
+                    else:
+                        if (linecache.getline(path, line + 1).
+                                startswith('snippet')):
                             end_line = line
-                        else:
-                            if (linecache.getline(path, line + 1).
-                                        startswith('snippet')):
-                                end_line = line
-                        if name_snippet and end_line and begin_line:
-                            data = {'path': path,
-                                        'name_snippet': name_snippet,
-                                        'begin_line': begin_line,
-                                        'end_line': end_line}
-                            self._add_extension_snippet(extension,
-                                                            name_snippet,
-                                                            data)
-                            name_snippet = None
-                            begin_line = None
-                            end_line = None
-                    if name_snippet and begin_line and not end_line:
+                    if name_snippet and end_line and begin_line:
                         data = {'path': path,
-                                    'name_snippet': name_snippet,
-                                    'begin_line': begin_line,
-                                    'end_line': line}
-                        self._add_extension_snippet(extension,
-                                                        name_snippet,
-                                                        data)
-            for extension, snippets in self.extension_snippet.items():
-                for name, snippet in snippets.items():
-                    if len(snippet) == 1:
-                        continue
-                    original = snippet[0]
-                    print "Snippet repeated for '%s' named '%s'" % (extension,
-                                                                    name)
-                    print "First defined in %s line(%s:%s)" % (
-                        original['path'], original['begin_line'],
-                        original['end_line'])
-                    print "+++++"
-                    duplicates = snippet[1:]
-                    for duplicate in duplicates:
-                        print "Snippet defined in %s line(%s:%s)" %(
-                            duplicate['path'], duplicate['begin_line'],
-                            duplicate['end_line'])
-                    print "+++++"
+                                'name_snippet': name_snippet,
+                                'begin_line': begin_line,
+                                'end_line': end_line}
+                        self._add_extension_snippet(extension, name_snippet,
+                                                    data)
+                        name_snippet = None
+                        begin_line = None
+                        end_line = None
+                if name_snippet and begin_line and not end_line:
+                    data = {'path': path,
+                            'name_snippet': name_snippet,
+                            'begin_line': begin_line,
+                            'end_line': line}
+                    self._add_extension_snippet(extension, name_snippet, data)
+        for extension, snippets in self.extension_snippet.items():
+            for name, snippet in snippets.items():
+                if len(snippet) == 1:
+                    continue
+                original = snippet[0]
+                print "Snippet repeated for '%s' named '%s'" % (extension,
+                                                                name)
+                print "First defined in %s line(%s:%s)" % (
+                     original['path'], original['begin_line'],
+                     original['end_line'])
+                print "+++++"
+                duplicates = snippet[1:]
+                for duplicate in duplicates:
+                    print "Snippet defined in %s line(%s:%s)" %(
+                         duplicate['path'], duplicate['begin_line'],
+                         duplicate['end_line'])
+                print "+++++"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix https://github.com/Vauxoo/docker-odoo-image/issues/199

This script can be run 
`python odoo-shippable/scripts/fix-vim-snippet.py --extension sh`

And the output is 
```
Snippet repeated for 'sh' named 'case'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(51:56)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(36:40)
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(24:28)
+++++
Snippet repeated for 'sh' named 'elif'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(58:61)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(17:19)
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(9:11)
+++++
Snippet repeated for 'sh' named 'sbash'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(36:41)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(8:12)
+++++
Snippet repeated for 'sh' named '#!'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(28:30)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(2:4)
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(2:4)
+++++
Snippet repeated for 'sh' named 'for'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(63:67)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(20:23)
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(12:15)
+++++
Snippet repeated for 'sh' named 'wh'
First defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(28:31)
+++++
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(16:19)
+++++
Snippet repeated for 'sh' named 'until'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(87:91)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(32:35)
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(20:23)
+++++
Snippet repeated for 'sh' named 'if'
First defined in /root/.vim/bundle/vim-snippets/UltiSnips/sh.snippets line(81:85)
+++++
Snippet defined in /root/.vim/bundle/vim-snippets/snippets/sh.snippets line(13:16)
Snippet defined in /root/.vim/bundle/vim-openerp/snippets/sh.snippets line(5:8)
+++++

```