### PR TITLE
Adding Vim option for repeated snipMate snippets

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -167,6 +167,12 @@ cat >> ~/.vimrc << EOF
 let g:signify_disable_by_default = 1 
 EOF
 
+# Overwrite repeated snipmate snippets
+cat >> ~/.vimrc << EOF
+" Overwrite repeated snipmate snippets
+let g:snipMate.override = 1
+EOF
+
 # Install and configure YouCompleteMe
 VIM_YOUCOMPLETEME_PATH="${HOME}/.vim/bundle/YouCompleteMe"
 git_clone_copy "${VIM_YOUCOMPLETEME_REPO}" "master" "." "${VIM_YOUCOMPLETEME_PATH}"


### PR DESCRIPTION
This option tells snipMate to not complain about repeated snippets and instead overwrite them with the last one loaded.

Fixes #199.