### PR TITLE
[FIX] Fixed the wkhtlptopdf version.

### DIFF
--- a/odoo90/scripts/build-image.sh
+++ b/odoo90/scripts/build-image.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
+# Exit inmediately after an error
+# See vauxoo/docker-odoo-image#108
+set -e
+
 # With a little help from my friends
 . /usr/share/vx-docker-internal/ubuntu-base/library.sh
 . /usr/share/vx-docker-internal/odoo90/library.sh
-
+. /etc/lsb-release
 # Let's set some defaults here
 ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-WKHTMLTOX_URL="http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-${ARCH}.tar.xz"
+WKHTMLTOX_URL="http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-${DISTRIB_CODENAME}-${ARCH}.deb"
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@8.0 \
                    git+https://github.com/vauxoo/server-tools@8.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@8.0 \
@@ -58,22 +62,10 @@ PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
                    mercurial==3.2.2 \
+                   setuptools==33.1.1 \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
 
-PIP_DPKG_BUILD_DEPENDS="gcc \
-                        g++ \
-                        gfortran \
-                        libblas-dev \
-                        liblapack-dev \
-                        cython \
-                        python-dev \
-                        libpq-dev \
-                        libldap2-dev \
-                        libsasl2-dev \
-                        libxml2-dev \
-                        libxslt1-dev \
-                        libgeoip-dev \
-                        zlib1g-dev"
+PIP_DPKG_BUILD_DEPENDS=""
 
 # Let's add the NodeJS upstream repo to install a newer version
 add_custom_aptsource "${NODE_UPSTREAM_REPO}" "${NODE_UPSTREAM_KEY}"
@@ -92,9 +84,6 @@ pip install --upgrade pip
 # Let's recursively find our pip dependencies
 collect_pip_dependencies "${ODOO_DEPENDENCIES}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
 
-# Cleans incorrect dependency lines
-clean_requirements ${DEPENDENCIES_FILE}
-
 # Install python dependencies
 pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 
@@ -106,7 +95,7 @@ apt-get purge ${PIP_DPKG_BUILD_DEPENDS} ${DPKG_UNNECESSARY}
 apt-get autoremove
 
 # Final cleaning
-find /tmp -type f -print0 | xargs -0r rm -rf
+rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf
 find /var/log -type f -print0 | xargs -0r rm -rf
 find /var/lib/apt/lists -type f -print0 | xargs -0r rm -rf

--- a/odoo90/scripts/library.sh
+++ b/odoo90/scripts/library.sh
@@ -52,20 +52,6 @@ x='''${1}'''
 print re.sub(regex, '', x)"
 }
 
-function clean_requirements(){
-    python -c "
-import re
-req = open('$1', 'r').read()
-req = list(set(req.split('\n')))
-req2 = []
-regex = r'([a-z](([0-9][a-z])|([a-z]+)))(((==|>=)[0-9].+)|'')'
-for i in req:
-    match = re.match(regex, i, re.I)
-    if match:
-        req2.append(i)
-open('$1', 'w').writelines('\n'.join(req2))"
-}
-
 function collect_pip_dependencies(){
     REPOLIST="${1}"
     DEPENDENCIES="${2}"
@@ -101,7 +87,7 @@ function collect_pip_dependencies(){
 function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
-    wget -qO- "${URL}" | tar -xJ -C "${DIR}/"
-    mv "${DIR}/wkhtmltox/bin/wkhtmltopdf" "/usr/local/bin/wkhtmltopdf"
-    rm -rf "${DIR}"
+    wget -q "${URL}" -O wkhtmltox.deb
+    dpkg -i wkhtmltox.deb
+    rm wkhtmltox.deb
 }


### PR DESCRIPTION
This change is made because the 8.0 and the 9.0 images are basically the same, the only differences are the pip dependencies. So we just added the corresponding file and keep everything else just the same.

This fixes the issue in abastotal instance with the reports are not being showed properly.

@moylop260 [here](https://github.com/Vauxoo/docker-odoo-image/pull/227) when we updated the 9.0 image the wkhtlmtopdf version was not updated properly. I just copied the 8.0 files and replaced to 9.0 where needed.