### PR TITLE
Add dependence setuptools odoo-shippable

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -51,7 +51,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="line-profiler watchdog coveralls diff-highlight \
-                   pg-activity virtualenv nodeenv"
+                   pg-activity virtualenv nodeenv setuptools==33.1.1"
 PIP_DPKG_BUILD_DEPENDS=""
 NPM_OPTS="-g"
 NPM_DEPENDS="localtunnel fs-extra eslint"


### PR DESCRIPTION
Add python dependency `setuptools==33.1.1` in odoo-shippable image

Because this error occurs

![error_build](https://cloud.githubusercontent.com/assets/16363083/26116125/0c4b274c-3a30-11e7-89dc-3771bc746929.png)
