### PR TITLE
[FIX] odoo-shippable: Install g++4.9 for new requirements of youcompleteme

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -2,7 +2,6 @@
 
 # Exit inmediately after an error
 set -e
-set -x
 
 # With a little help from my friends
 . /usr/share/vx-docker-internal/ubuntu-base/library.sh
@@ -176,8 +175,7 @@ sed -i 's/robbyrussell/odoo-shippable/g' ~/.zshrc
 
 # Upgrade & configure vim
 apt-get upgrade vim
-tree -d /usr/share/vim
-wget -q -O /usr/share/vim/vim80/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
+wget -q -O /usr/share/vim/vim80/spell/es.utf-8.spl ftp://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
 git_clone_execute "${SPF13_REPO}" "3.0" "bootstrap.sh"
 git_clone_copy "${VIM_OPENERP_REPO}" "master" "vim/" "${HOME}/.vim/bundle/vim-openerp"
 

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -2,6 +2,7 @@
 
 # Exit inmediately after an error
 set -e
+set -x
 
 # With a little help from my friends
 . /usr/share/vx-docker-internal/ubuntu-base/library.sh

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -176,6 +176,7 @@ sed -i 's/robbyrussell/odoo-shippable/g' ~/.zshrc
 
 # Upgrade & configure vim
 apt-get upgrade vim
+tree -d /usr/share/vim
 wget -q -O /usr/share/vim/vim80/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
 git_clone_execute "${SPF13_REPO}" "3.0" "bootstrap.sh"
 git_clone_copy "${VIM_OPENERP_REPO}" "master" "vim/" "${HOME}/.vim/bundle/vim-openerp"

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -18,8 +18,8 @@ GITCORE_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xA1
 # ppa sources
 PYTHON_PPA_REPO="deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main"
 PYTHON_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x5BB92C09DB82666C"
-VIM_PPA_REPO="deb http://ppa.launchpad.net/pkg-vim/vim-daily/ubuntu trusty main"
-VIM_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xA7266A2DD31525A0"
+VIM_PPA_REPO="deb http://ppa.launchpad.net/jonathonf/vim/ubuntu trusty main"
+VIM_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x8CF63AD3F06FC659"
 GCC_PPA_REPO="deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main"
 GCC_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x1E9377A2BA9EF27F"
 
@@ -175,7 +175,7 @@ sed -i 's/robbyrussell/odoo-shippable/g' ~/.zshrc
 
 # Upgrade & configure vim
 apt-get upgrade vim
-wget -q -O /usr/share/vim/vim74/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
+wget -q -O /usr/share/vim/vim80/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
 git_clone_execute "${SPF13_REPO}" "3.0" "bootstrap.sh"
 git_clone_copy "${VIM_OPENERP_REPO}" "master" "vim/" "${HOME}/.vim/bundle/vim-openerp"
 

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -20,6 +20,8 @@ PYTHON_PPA_REPO="deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty ma
 PYTHON_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x5BB92C09DB82666C"
 VIM_PPA_REPO="deb http://ppa.launchpad.net/pkg-vim/vim-daily/ubuntu trusty main"
 VIM_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xA7266A2DD31525A0"
+GCC_PPA_REPO="deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main"
+GCC_PPA_KEY="http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x1E9377A2BA9EF27F"
 
 # Extra software download URLs
 HUB_ARCHIVE="https://github.com/github/hub/releases/download/v2.2.3/hub-linux-${ARCH}-2.2.3.tgz"
@@ -47,7 +49,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
               lua50 liblua50-dev liblualib50-dev exuberant-ctags rake \
               python3.3 python3.3-dev python3.4 python3.4-dev python3.5 python3.5-dev python3.6 python3.6-dev \
               software-properties-common Xvfb libmagickwand-dev openjdk-7-jre \
-              dos2unix"
+              dos2unix gcc-4.9 g++-4.9 cpp-4.9"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="line-profiler watchdog coveralls diff-highlight \
@@ -63,11 +65,19 @@ add_custom_aptsource "${GITCORE_PPA_REPO}" "${GITCORE_PPA_KEY}"
 add_custom_aptsource "${PYTHON_PPA_REPO}" "${PYTHON_PPA_KEY}"
 # Let's add the vim ppa for having a more up-to-date vim
 add_custom_aptsource "${VIM_PPA_REPO}" "${VIM_PPA_KEY}"
+# Let's add the vim ppa for having a more up-to-date gcc, g++, cpp
+add_custom_aptsource "${GCC_PPA_REPO}" "${GCC_PPA_KEY}"
 
 # Release the apt monster!
 apt-get update
 apt-get upgrade
 apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
+
+# Use the 4.9 for default
+rm /usr/bin/gcc /usr/bin/g++ /usr/bin/cpp
+ln -s /usr/bin/gcc-4.9 /usr/bin/gcc
+ln -s /usr/bin/g++-4.9 /usr/bin/g++
+ln -s /usr/bin/cpp-4.9 /usr/bin/cpp
 
 # Install node dependencies
 npm install ${NPM_OPTS} ${NPM_DEPENDS}


### PR DESCRIPTION
The new version of youcompleteme require g++-4.9 instead of g++-4.8 https://github.com/Valloric/YouCompleteMe/commit/b20809332c3298cb954cff20006cb52955b54b2d#diff-354f30a63fb0907d4ad57269548329e3L37

This PR adding new ppa for install the version 4.9 of g++

Currently when I made one build of odoo-shippable show the following error

![image](https://user-images.githubusercontent.com/1387970/26940185-c2256d42-4c47-11e7-9af4-d7c8c0eef701.png)

Fix https://github.com/Vauxoo/docker-odoo-image/issues/236
