### PR TITLE
[FIX] odoo-shippable: Not install the youcompleteme

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -186,9 +186,8 @@ EOF
 
 # Install and configure YouCompleteMe
 VIM_YOUCOMPLETEME_PATH="${HOME}/.vim/bundle/YouCompleteMe"
-git_clone_copy "${VIM_YOUCOMPLETEME_REPO}" "master" "." "${VIM_YOUCOMPLETEME_PATH}"
-# The version required by youcompleteme is g++4.9
-#(cd "${VIM_YOUCOMPLETEME_PATH}" && ./install.py)
+git clone ${VIM_YOUCOMPLETEME_REPO} ${VIM_YOUCOMPLETEME_PATH}
+(cd "${VIM_YOUCOMPLETEME_PATH}" && git reset --hard 89beeb518ef0a85346b6c65e13baab24dcaef37c && git submodule update --init --recursive && ./install.py)
 cat >> ~/.vimrc << EOF
 " Disable auto trigger for youcompleteme
 let g:ycm_auto_trigger = 0

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -187,6 +187,7 @@ EOF
 # Install and configure YouCompleteMe
 VIM_YOUCOMPLETEME_PATH="${HOME}/.vim/bundle/YouCompleteMe"
 git clone ${VIM_YOUCOMPLETEME_REPO} ${VIM_YOUCOMPLETEME_PATH}
+# Install the custom version of YouCompleteMe because the last required g++ 4.9
 (cd "${VIM_YOUCOMPLETEME_PATH}" && git reset --hard 89beeb518ef0a85346b6c65e13baab24dcaef37c && git submodule update --init --recursive && ./install.py)
 cat >> ~/.vimrc << EOF
 " Disable auto trigger for youcompleteme
@@ -243,7 +244,7 @@ EOF
 cat >> ~/.vimrc.before.local << EOF
 # Disabled 'youcompleteme' by default
 let g:spf13_bundle_groups = ['general', 'writing', 'odoovim', 'wakatime',
-                           \ 'programming', 'php', 'ruby',
+                           \ 'programming', 'youcompleteme', 'php', 'ruby',
                            \ 'python', 'javascript', 'html',
                            \ 'misc']
 EOF

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -187,7 +187,8 @@ EOF
 # Install and configure YouCompleteMe
 VIM_YOUCOMPLETEME_PATH="${HOME}/.vim/bundle/YouCompleteMe"
 git_clone_copy "${VIM_YOUCOMPLETEME_REPO}" "master" "." "${VIM_YOUCOMPLETEME_PATH}"
-(cd "${VIM_YOUCOMPLETEME_PATH}" && ./install.py)
+# The version required by youcompleteme is g++4.9
+#(cd "${VIM_YOUCOMPLETEME_PATH}" && ./install.py)
 cat >> ~/.vimrc << EOF
 " Disable auto trigger for youcompleteme
 let g:ycm_auto_trigger = 0


### PR DESCRIPTION
Youcompleteme required the version `g++4.9`, and the version into the imagen is `g++4.8`

![image](https://user-images.githubusercontent.com/1387970/27453860-d29e9be8-5765-11e7-8f72-cc917adbee5a.png)

![image](https://user-images.githubusercontent.com/1387970/27453844-c8c4375e-5765-11e7-8683-b62d23d0e8a6.png)