### PR TITLE
[FIX] odoo-shippable: Install old version of youcompleteme

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -188,7 +188,7 @@ EOF
 VIM_YOUCOMPLETEME_PATH="${HOME}/.vim/bundle/YouCompleteMe"
 git clone ${VIM_YOUCOMPLETEME_REPO} ${VIM_YOUCOMPLETEME_PATH}
 # Install the custom version of YouCompleteMe because the last required g++ 4.9
-(cd "${VIM_YOUCOMPLETEME_PATH}" && git reset --hard 89beeb518ef0a85346b6c65e13baab24dcaef37c && git submodule update --init --recursive && ./install.py)
+(cd "${VIM_YOUCOMPLETEME_PATH}" && git reset --hard c31152d34591f3211799ca1fe918eb78487e6dde && git submodule update --init --recursive && ./install.py)
 cat >> ~/.vimrc << EOF
 " Disable auto trigger for youcompleteme
 let g:ycm_auto_trigger = 0
@@ -242,7 +242,6 @@ endif
 EOF
 
 cat >> ~/.vimrc.before.local << EOF
-# Disabled 'youcompleteme' by default
 let g:spf13_bundle_groups = ['general', 'writing', 'odoovim', 'wakatime',
                            \ 'programming', 'youcompleteme', 'php', 'ruby',
                            \ 'python', 'javascript', 'html',


### PR DESCRIPTION
In this version of `youcompleteme` https://github.com/Valloric/YouCompleteMe/blob/c31152d34591f3211799ca1fe918eb78487e6dde/plugin/youcompleteme.vim the version required is `Vim 7.4.143.`

This is the version installed for default on odoo-shippable

With this change now the youcompleteme work fine
![image](https://user-images.githubusercontent.com/1387970/27592042-7c2a496e-5b21-11e7-88d3-cc9ceefedf67.png)

Fix https://github.com/Vauxoo/docker-odoo-image/issues/244