### PR TITLE
[FIX] Fix the error raised when build the image

### DIFF
--- a/odoo100/scripts/10.0-full_requirements.txt
+++ b/odoo100/scripts/10.0-full_requirements.txt
@@ -28,4 +28,3 @@ validate_email
 sphinx-patchqueue==0.4.0
 sphinx==1.2.3
 unidecode
-git+https://github.com/savoirfairelinux/num2words.git@0.5.4

--- a/odoo100/scripts/10.0-full_requirements.txt
+++ b/odoo100/scripts/10.0-full_requirements.txt
@@ -29,5 +29,3 @@ sphinx-patchqueue==0.4.0
 sphinx==1.2.3
 unidecode
 git+https://github.com/savoirfairelinux/num2words.git@0.5.4
-git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo
-git+https://github.com/vauxoo/panama-dv@master#egg=ruc

--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -61,6 +61,9 @@ PIP_OPTS="--upgrade \
 
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
                    mercurial==3.2.2 \
+                   setuptools==33.1.1 \
+                   git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
+                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
 
 PIP_DPKG_BUILD_DEPENDS=""

--- a/odoo80/scripts/8.0-full_requirements.txt
+++ b/odoo80/scripts/8.0-full_requirements.txt
@@ -10,13 +10,10 @@ mygengo
 recaptcha-client
 egenix-mx-base
 branchesv
-git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo
-git+https://github.com/vauxoo/panama-dv@master#egg=ruc
 requirements-parser==0.1.0
 setuptools==33.1.1
 pstats_print2list
 py2-ipaddress==3.4.1
-git+https://github.com/vauxoo/panama-dv.git
 numexpr
 twilio==5.4.0
 validate_email

--- a/odoo80/scripts/8.0-full_requirements.txt
+++ b/odoo80/scripts/8.0-full_requirements.txt
@@ -14,7 +14,6 @@ requirements-parser==0.1.0
 setuptools==33.1.1
 pstats_print2list
 py2-ipaddress==3.4.1
-numexpr
 twilio==5.4.0
 validate_email
 yowsup2==2.3.185

--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -63,6 +63,8 @@ PIP_OPTS="--upgrade \
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
                    mercurial==3.2.2 \
                    setuptools==33.1.1 \
+                   git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
+                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
 
 PIP_DPKG_BUILD_DEPENDS=""
@@ -83,6 +85,9 @@ pip install --upgrade pip
 
 # Let's recursively find our pip dependencies
 collect_pip_dependencies "${ODOO_DEPENDENCIES}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
+
+# Cleans incorrect dependency lines  
+clean_requirements ${DEPENDENCIES_FILE}
 
 # Install python dependencies
 pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}

--- a/odoo80/scripts/library.sh
+++ b/odoo80/scripts/library.sh
@@ -52,6 +52,20 @@ x='''${1}'''
 print re.sub(regex, '', x)"
 }
 
+function clean_requirements(){
+    python -c "
+import re
+req = open('$1', 'r').read()
+req = list(set(req.split('\n')))
+req2 = []
+regex = r'([a-z](([0-9][a-z])|([a-z]+)))(((==|>=)[0-9].+)|'')'
+for i in req:
+    match = re.match(regex, i, re.I)
+    if match:
+        req2.append(i)
+open('$1', 'w').writelines('\n'.join(req2))"
+}
+
 function collect_pip_dependencies(){
     REPOLIST="${1}"
     DEPENDENCIES="${2}"

--- a/odoo90/scripts/9.0-full_requirements.txt
+++ b/odoo90/scripts/9.0-full_requirements.txt
@@ -12,8 +12,6 @@ mygengo
 recaptcha-client
 egenix-mx-base
 setuptools==33.1.1
-git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo
-git+https://github.com/vauxoo/panama-dv@master#egg=ruc
 unidecode
 cssutils>=1.0.1
 xlsxwriter==0.9.4
@@ -34,3 +32,4 @@ json2html===1.0.1
 odoorpc
 git+https://github.com/savoirfairelinux/num2words.git@0.5.4
 IPy
+

--- a/odoo90/scripts/build-image.sh
+++ b/odoo90/scripts/build-image.sh
@@ -63,6 +63,8 @@ PIP_OPTS="--upgrade \
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
                    mercurial==3.2.2 \
                    setuptools==33.1.1 \
+                   git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
+                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
 
 PIP_DPKG_BUILD_DEPENDS=""


### PR DESCRIPTION
Seems that a dependency is braking the install process of panama-dv and pylint-odoo, but I still can't find why and what package do that, but it seems that installing them first solve the issue by now.

@moylop260 Moving the dependencies to be installed before the requirements file seems to fix this by now, I'm still trying to find exactly what's the dependency that is braking the build because it is not panama-dv nor pylint-odoo.

I'll leave this here in case you want to use this as a workaround while I try to find the real fix for the error