### PR TITLE
[IMP] odoo-shippable: convert all files to unix format

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -226,6 +226,9 @@ let g:SuperTabDefaultCompletionType = '<C-n>'
 let g:UltiSnipsExpandTrigger = "<tab>"
 let g:UltiSnipsJumpForwardTrigger = "<tab>"
 let g:UltiSnipsJumpBackwardTrigger = "<s-tab>"
+
+" Convert all files to unix format on open
+au BufRead,BufNewFile * set ff=unix
 EOF
 
 cat >> ~/.vimrc.bundles.local << EOF


### PR DESCRIPTION
After this PR, now all files are converted to unix file format when the file is opened using VIM.

You can test this changes cloning this repository and building the docker image:

cd odoo-shippable
docker build -t vim-unix .
docker run -it vim-unix bash