### PR TITLE
[FIX] odoo-shippable: The command install_plugins.sh should be ran with the odoo user

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -420,7 +420,7 @@ cp -r ${HOME}/.tmux.conf /home/odoo
 chown -R odoo:odoo /home/odoo/.tmux.conf
 # Install all plugin for all user
 ${HOME}/.tmux/plugins/tpm/scripts/install_plugins.sh
-/home/odoo/.tmux/plugins/tpm/scripts/install_plugins.sh
+su odoo /home/odoo/.tmux/plugins/tpm/scripts/install_plugins.sh
 
 # Set custom configuration of max connections, port and locks for postgresql
 sed -i 's/#max_pred_locks_per_transaction = 64/max_pred_locks_per_transaction = 100/g' /etc/postgresql/*/main*/postgresql.conf


### PR DESCRIPTION
The command `install_plugins.sh` should be ran with the odoo user to create the folder inside the odoo home

You can test that change cloning this repository and build the docker

`cd odoo-shippable`
`docker build -t tmux-resurrect .`
`docker run -it tmux-resurect bash`

Fix https://github.com/Vauxoo/docker-odoo-image/issues/266