### PR TITLE
[ADD] odoo-shippable: Adding virtualenv for each version of python installed

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -123,7 +123,6 @@ do
     clean_requirements ${DEPENDENCIES_FILE}
     python"$version" -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 done
-exit 0
 
 # Install xvfb daemon
 wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/cookbooks/travis_build_environment/files/default/etc-init.d-xvfb.sh -O /etc/init.d/xvfb

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -64,7 +64,7 @@ ODOO_DEPENDENCIES_PY2="git+https://github.com/vauxoo/odoo@10.0 \
 
 ODOO_DEPENDENCIES_PY3="git+https://github.com/vauxoo/odoo@saas-17"
 
-DEPENDENCIES_FILE="/tmp/full_requirements_2.txt"
+DEPENDENCIES_FILE="/tmp/full_requirements.txt"
 
 NPM_OPTS="-g"
 NPM_DEPENDS="localtunnel fs-extra eslint"
@@ -109,14 +109,15 @@ sed -i 's/graceful-fs/fs-extra/g;s/fs.rename/fs.move/g' $(npm root -g)/npm/lib/u
 #pip install ${PIP_OPTS} ${PIP_DEPENDS_EXTRA}
 
 echo "Install all pip dependencies for python2.7"
+echo "" > ${DEPENDENCIES_FILE}
 collect_pip_dependencies "${ODOO_DEPENDENCIES_PY2}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
 clean_requirements ${DEPENDENCIES_FILE}
 python2.7 -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 
 # TODO fix 3.2
-DEPENDENCIES_FILE="/tmp/full_requirements_3.txt"
 for version in '3.3' '3.4' '3.5' '3.6'
 do
+    echo "" > ${DEPENDENCIES_FILE}
     echo "Install all pip dependencies for python${version}"
     collect_pip_dependencies "${ODOO_DEPENDENCIES_PY3}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
     clean_requirements ${DEPENDENCIES_FILE}

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -145,9 +145,13 @@ git_clone_copy "${PYLINT_REPO}" "master" "conf/.jslintrc" "${REPO_REQUIREMENTS}/
 ln -sf ${REPO_REQUIREMENTS}/linit_hook/git/* /usr/share/git-core/templates/hooks/
 
 # Creating virtual environments for all version installed of python
-# TODO Fix the version 3.2
+echo "Create the virtualenv using python3.2"
+python3.2 -m pip uninstall -y virtualenv
+python3.2 -m pip install virtualenv==13.1.2
+python3.2 -m virtualenv -p /usr/bin/python3.2 --system-site-packages ${REPO_REQUIREMENTS}/virtualenv/python3.2
 for version in '2.7' '3.3' '3.4' '3.5' '3.6'
 do
+    echo "Create the virtualenv using python${version}"
     python${version} -m virtualenv -p /usr/bin/python${version} --system-site-packages ${REPO_REQUIREMENTS}/virtualenv/python${version}
 done
 export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -64,8 +64,7 @@ ODOO_DEPENDENCIES_PY2="git+https://github.com/vauxoo/odoo@10.0 \
 
 ODOO_DEPENDENCIES_PY3="git+https://github.com/vauxoo/odoo@saas-17"
 
-DEPENDENCIES_FILE_PY2="/tmp/full_requirements_2.txt"
-DEPENDENCIES_FILE_PY3="/tmp/full_requirements_3.txt"
+DEPENDENCIES_FILE="/tmp/full_requirements_2.txt"
 
 NPM_OPTS="-g"
 NPM_DEPENDS="localtunnel fs-extra eslint"
@@ -110,17 +109,18 @@ sed -i 's/graceful-fs/fs-extra/g;s/fs.rename/fs.move/g' $(npm root -g)/npm/lib/u
 #pip install ${PIP_OPTS} ${PIP_DEPENDS_EXTRA}
 
 echo "Install all pip dependencies for python2.7"
-collect_pip_dependencies "${ODOO_DEPENDENCIES_PY2}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE_PY2}"
-clean_requirements ${DEPENDENCIES_FILE_PY2}
-python2.7 -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE_PY2}
+collect_pip_dependencies "${ODOO_DEPENDENCIES_PY2}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
+clean_requirements ${DEPENDENCIES_FILE}
+python2.7 -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 
 # TODO fix 3.2
+DEPENDENCIES_FILE="/tmp/full_requirements_3.txt"
 for version in '3.3' '3.4' '3.5' '3.6'
 do
     echo "Install all pip dependencies for python${version}"
-    collect_pip_dependencies "${ODOO_DEPENDENCIES_PY3}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE_PY3}"
-    clean_requirements ${DEPENDENCIES_FILE_PY3}
-    python"$version" -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE_PY3}
+    collect_pip_dependencies "${ODOO_DEPENDENCIES_PY3}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
+    clean_requirements ${DEPENDENCIES_FILE}
+    python"$version" -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 done
 exit 0
 

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -407,27 +407,17 @@ sed -i 's/root/home\/odoo/g' /home/odoo/.zshrc
 usermod -s /bin/bash root
 
 # Export another PYTHONPATH and activate the virtualenvironment
-cat >> ${HOME}/.bashrc << EOF
-source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate
+for $_FILE in '${HOME}/.bashrc' '/home/odoo/.bashrc' '${HOME}/.zshrc' '/home/odoo/.zshrc'
+do
+    cat >> ${_FILE} << EOF
+if [ "x\${TRAVIS_PYTHON_VERSION}" == "x" ] ; then
+    TRAVIS_PYTHON_VERSION="2.7"
+fi
+source ${REPO_REQUIREMENTS}/virtualenv/python\${TRAVIS_PYTHON_VERSION}/bin/activate
 source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
 PYTHONPATH=${PYTHONPATH}:${REPO_REQUIREMENTS}/odoo
 EOF
-cat >> /home/odoo/.bashrc << EOF
-source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate
-source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
-PYTHONPATH=${PYTHONPATH}:${REPO_REQUIREMENTS}/odoo
-EOF
-
-cat >> ${HOME}/.zshrc << EOF
-source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate
-source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
-PYTHONPATH=${PYTHONPATH}:${REPO_REQUIREMENTS}/odoo
-EOF
-cat >> /home/odoo/.zshrc << EOF
-source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate
-source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
-PYTHONPATH=${PYTHONPATH}:${REPO_REQUIREMENTS}/odoo
-EOF
+done
 
 # Install Tmux Plugin Manager
 git_clone_copy "${TMUX_PLUGINS_REPO}" "master" "" "${HOME}/.tmux/plugins/tpm"

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -59,11 +59,14 @@ PIP_DEPENDS_EXTRA="line-profiler watchdog coveralls diff-highlight \
                    html2text==2016.9.19 ofxparse==0.15"
 PIP_DPKG_BUILD_DEPENDS=""
 
-ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@10.0 \
-                   git+https://github.com/vauxoo/odoo@saas-15 \
-                   git+https://github.com/vauxoo/odoo@saas-17"
+ODOO_DEPENDENCIES_PY2="git+https://github.com/vauxoo/odoo@10.0 \
+                       git+https://github.com/vauxoo/odoo@saas-15"
 
-DEPENDENCIES_FILE="/tmp/full_requirements.txt"
+ODOO_DEPENDENCIES_PY3="git+https://github.com/vauxoo/odoo@saas-17"
+
+DEPENDENCIES_FILE_PY2="/tmp/full_requirements_2.txt"
+DEPENDENCIES_FILE_PY3="/tmp/full_requirements_3.txt"
+
 NPM_OPTS="-g"
 NPM_DEPENDS="localtunnel fs-extra eslint"
 
@@ -106,9 +109,20 @@ sed -i 's/graceful-fs/fs-extra/g;s/fs.rename/fs.move/g' $(npm root -g)/npm/lib/u
 # Install python dependencies
 #pip install ${PIP_OPTS} ${PIP_DEPENDS_EXTRA}
 
-collect_pip_dependencies "${ODOO_DEPENDENCIES}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
-clean_requirements ${DEPENDENCIES_FILE}
-pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
+echo "Install all pip dependencies for python2.7"
+collect_pip_dependencies "${ODOO_DEPENDENCIES_PY2}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE_PY2}"
+clean_requirements ${DEPENDENCIES_FILE_PY2}
+python2.7 -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE_PY2}
+
+# TODO fix 3.2
+for version in '3.3' '3.4' '3.5' '3.6'
+do
+    echo "Install all pip dependencies for python${version}"
+    collect_pip_dependencies "${ODOO_DEPENDENCIES_PY3}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE_PY3}"
+    clean_requirements ${DEPENDENCIES_FILE_PY3}
+    python"$version" -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE_PY3}
+done
+exit 0
 
 # Install xvfb daemon
 wget https://raw.githubusercontent.com/travis-ci/travis-cookbooks/master/cookbooks/travis_build_environment/files/default/etc-init.d-xvfb.sh -O /etc/init.d/xvfb

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -145,7 +145,8 @@ git_clone_copy "${PYLINT_REPO}" "master" "conf/.jslintrc" "${REPO_REQUIREMENTS}/
 ln -sf ${REPO_REQUIREMENTS}/linit_hook/git/* /usr/share/git-core/templates/hooks/
 
 # Creating virtual environments for all version installed of python
-for version in '2.7' '3.2' '3.3' '3.4' '3.5' '3.6'
+# TODO Fix the version 3.2
+for version in '2.7' '3.3' '3.4' '3.5' '3.6'
 do
     python${version} -m virtualenv -p /usr/bin/python${version} --system-site-packages ${REPO_REQUIREMENTS}/virtualenv/python${version}
 done

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -144,10 +144,15 @@ git_clone_copy "${PYLINT_REPO}" "master" "conf/pylint_vauxoo_light_vim.cfg" "${R
 git_clone_copy "${PYLINT_REPO}" "master" "conf/.jslintrc" "${REPO_REQUIREMENTS}/linit_hook/travis/cfg/.jslintrc"
 ln -sf ${REPO_REQUIREMENTS}/linit_hook/git/* /usr/share/git-core/templates/hooks/
 
-# Creating virtual environments for python and node js
+# Creating virtual environments for all version installed of python
+for version in '2.7' '3.2' '3.3' '3.4' '3.5' '3.6'
+do
+    python${version} -m virtualenv -p /usr/bin/python${version} --system-site-packages ${REPO_REQUIREMENTS}/virtualenv/python${version}
+done
 export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7
 echo "VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7" >> /etc/bash.bashrc
-virtualenv -p /usr/bin/python2 --system-site-packages ${REPO_REQUIREMENTS}/virtualenv/python2.7
+
+# Creating virtual environments node js
 nodeenv ${REPO_REQUIREMENTS}/virtualenv/nodejs
 echo "REPO_REQUIREMENTS=${REPO_REQUIREMENTS}" >> /etc/bash.bashrc
 

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -406,9 +406,10 @@ sed -i 's/root/home\/odoo/g' /home/odoo/.zshrc
 usermod -s /bin/bash root
 
 # Export another PYTHONPATH and activate the virtualenvironment
-for $_FILE in '${HOME}/.bashrc' '/home/odoo/.bashrc' '${HOME}/.zshrc' '/home/odoo/.zshrc'
+for BASHRC in ${HOME}/.bashrc /home/odoo/.bashrc ${HOME}/.zshrc /home/odoo/.zshrc
 do
-    cat >> ${_FILE} << EOF
+    echo "Export the PYTHONPATH IN ${BASHRC}"
+    cat >> $BASHRC << EOF
 if [ "x\${TRAVIS_PYTHON_VERSION}" == "x" ] ; then
     TRAVIS_PYTHON_VERSION="2.7"
 fi

--- a/odoo-shippable/scripts/entrypoint_image
+++ b/odoo-shippable/scripts/entrypoint_image
@@ -82,7 +82,7 @@ def docker_entrypoint():
             stderr=subprocess.PIPE)
         psql_subprocess.wait()
         psql_out = psql_subprocess.stderr.read()
-        if 'rol' in psql_out and 'does not exist' in psql_out:
+        if b'rol' in psql_out and b'does not exist' in psql_out:
             psql_error = False
         elif psql_out:
             psql_error = True

--- a/odoo80/scripts/8.0-full_requirements.txt
+++ b/odoo80/scripts/8.0-full_requirements.txt
@@ -1,8 +1,5 @@
 pillow-pil
-M2Crypto
 GeoIP
-SOAPpy
-xmltodict
 flake8
 pylint-mccabe
 PyWebDAV
@@ -22,11 +19,9 @@ num2words
 xlrd>=1.0.0
 IPy
 unidecode
-pandas == 0.18.0
+pandas==0.18.0
 cssutils >= 1.0.1
-xlrd==1.0.0
 pyotp==2.0.1
-pandas
 python-stdnum==1.1
 tabulate == 0.7.5
 m2crypto==0.25.1
@@ -39,8 +34,6 @@ odoorpc
 workalendar == 0.8.0
 acme_tiny
 pyopenssl>=16.2.0
-pandas==0.18.0
-xlrd == 1.0.0
 numexpr==2.6.1
 SOAPpy==0.12.22
 unicodecsv

--- a/odoo80/scripts/library.sh
+++ b/odoo80/scripts/library.sh
@@ -93,9 +93,9 @@ function collect_pip_dependencies(){
 
     pip install ${PIP_OPTS} ${DEPENDENCIES}
 
-    #for REQ in $( find ${TEMPDIR} -maxdepth 1 -type f -iname "requirements.txt" ); do
-    /usr/share/vx-docker-internal/odoo80/gen_pip_deps "${TEMPDIR}/requirements.txt" ${DEPENDENCIES_FILE}
-    #done
+    for REQ in $( find ${TEMPDIR} -maxdepth 1 -type f -iname "requirements.txt" ); do
+        /usr/share/vx-docker-internal/odoo80/gen_pip_deps ${REQ} ${DEPENDENCIES_FILE}
+    done
 }
 
 function wkhtmltox_install(){

--- a/odoo80/scripts/library.sh
+++ b/odoo80/scripts/library.sh
@@ -93,7 +93,7 @@ function collect_pip_dependencies(){
 
     pip install ${PIP_OPTS} ${DEPENDENCIES}
 
-    for REQ in $( find ${TEMPDIR} -type f -iname "requirements.txt" ); do
+    for REQ in $( find ${TEMPDIR} -maxdepth 1 -type f -iname "requirements.txt" ); do
         /usr/share/vx-docker-internal/odoo80/gen_pip_deps ${REQ} ${DEPENDENCIES_FILE}
     done
 }

--- a/odoo80/scripts/library.sh
+++ b/odoo80/scripts/library.sh
@@ -93,9 +93,9 @@ function collect_pip_dependencies(){
 
     pip install ${PIP_OPTS} ${DEPENDENCIES}
 
-    for REQ in $( find ${TEMPDIR} -maxdepth 1 -type f -iname "requirements.txt" ); do
-        /usr/share/vx-docker-internal/odoo80/gen_pip_deps ${REQ} ${DEPENDENCIES_FILE}
-    done
+    #for REQ in $( find ${TEMPDIR} -maxdepth 1 -type f -iname "requirements.txt" ); do
+    /usr/share/vx-docker-internal/odoo80/gen_pip_deps "${TEMPDIR}/requirements.txt" ${DEPENDENCIES_FILE}
+    #done
 }
 
 function wkhtmltox_install(){


### PR DESCRIPTION
The follow version of python they were created the virtualenv and install all dependencies of odoo
- `3.3`
- `3.4`
- `3.5`
- `3.6`

Something requirements in `odoo80/scripts/8.0-full_requirements.txt` were deleted because they are repeated
