### PR TITLE
[FIX] Install dev packages for postgres to avoid the exception.

### DIFF
--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -52,6 +52,7 @@ DPKG_DEPENDS="nodejs \
               postgresql-${PSQL_VERSION} \
               postgresql-client-${PSQL_VERSION} \
               postgresql-contrib-${PSQL_VERSION} \
+              postgresql-server-dev-${PSQL_VERSION} \
               pgbadger \
               python-cups"
 DPKG_UNNECESSARY=""

--- a/odoo90/scripts/build-image.sh
+++ b/odoo90/scripts/build-image.sh
@@ -52,6 +52,7 @@ DPKG_DEPENDS="nodejs \
               postgresql-${PSQL_VERSION} \
               postgresql-client-${PSQL_VERSION} \
               postgresql-contrib-${PSQL_VERSION} \
+              postgresql-server-dev-${PSQL_VERSION} \
               pgbadger"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"


### PR DESCRIPTION
We need to install postgresql-server-dev so the pg_config commands shows the proper version, at the moment it shows 10.0 even when only the 9.6 is installed. This issue was fixed in pycopg 2.7, but not in the previous versions: https://github.com/psycopg/psycopg2/issues/594

This patch only apply for the images that uses older pycopg versions, that is 8.0 and 9.0 because 10 and 11 use 2.7.

Before this patch:

![a](http://screenshots.vauxoo.com/tulio/13532228417-JblfuuX7Kt.jpg)

After this patch:

![b](http://screenshots.vauxoo.com/tulio/13540028417-gBhixVOd3h.jpg)