### PR TITLE
[FIX] Set 3.5 as default python3 and pip3 version.

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -176,6 +176,12 @@ done
 export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7
 echo "VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7" >> /etc/bash.bashrc
 
+# Change default python and pip 3 version from 3.4 to 3.5 and
+rm /usr/bin/python3
+ln -s /usr/bin/python3.5 /usr/bin/python3
+rm /usr/local/bin/pip3
+ln -s /usr/local/bin/pip3.5 /usr/local/bin/pip3
+
 # Creating virtual environments node js
 nodeenv ${REPO_REQUIREMENTS}/virtualenv/nodejs
 echo "REPO_REQUIREMENTS=${REPO_REQUIREMENTS}" >> /etc/bash.bashrc


### PR DESCRIPTION
This change is needed because the production images use python 3.5 which is the one that comes by default with Ubuntu 16.04 (the one used for all p3 odoo instances).

@moylop260 Is there any suggested P3 version for Odoo? if not this change is for having the same version as in production (3.5) also changes the pip3 default:

![a](http://screenshots.vauxoo.com/tulio/12252929817-p0eqord8hj.jpg)

Which didn't match python3 default:

![b](http://screenshots.vauxoo.com/tulio/12260529817-ZwcDmfH6au.jpg)

To 3.5:

![c](http://screenshots.vauxoo.com/tulio/12263729817-q5MVDDVmFE.jpg)