### PR TITLE
[FIX] odoo-shippable: Active the virtual environment in the top of the .bashrc

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -412,12 +412,17 @@ usermod -s /bin/bash root
 for BASHRC in ${HOME}/.bashrc /home/odoo/.bashrc ${HOME}/.zshrc /home/odoo/.zshrc
 do
     echo "Export the PYTHONPATH IN ${BASHRC}"
-    sed -i '1 i\if [ "x${TRAVIS_PYTHON_VERSION}" == "x"  ] ; then\n
-                    \tTRAVIS_PYTHON_VERSION="2.7"\n
-                fi\n
-                source /.repo_requirements/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/activate\n
-                source /.repo_requirements/virtualenv/nodejs/bin/activate\n
-                PYTHONPATH=:/.repo_requirements/odoo\n\n' $BASHRC
+    sed -i '1 i\# Python path \
+if [ "x${TRAVIS_PYTHON_VERSION}" == "x"  ] ; then \
+    TRAVIS_PYTHON_VERSION="2.7" \
+fi \
+source /.repo_requirements/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/activate \
+source /.repo_requirements/virtualenv/nodejs/bin/activate \
+PYTHONPATH=${PYTHONPATH}:${REPO_REQUIREMENTS}/odoo\n\n' $BASHRC
+	cat >> $BASHRC << EOF
+source ${REPO_REQUIREMENTS}/virtualenv/python\${TRAVIS_PYTHON_VERSION}/bin/activate
+source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
+EOF
 done
 
 # Install Tmux Plugin Manager

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -412,14 +412,12 @@ usermod -s /bin/bash root
 for BASHRC in ${HOME}/.bashrc /home/odoo/.bashrc ${HOME}/.zshrc /home/odoo/.zshrc
 do
     echo "Export the PYTHONPATH IN ${BASHRC}"
-    cat >> $BASHRC << EOF
-if [ "x\${TRAVIS_PYTHON_VERSION}" == "x" ] ; then
-    TRAVIS_PYTHON_VERSION="2.7"
-fi
-source ${REPO_REQUIREMENTS}/virtualenv/python\${TRAVIS_PYTHON_VERSION}/bin/activate
-source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
-PYTHONPATH=${PYTHONPATH}:${REPO_REQUIREMENTS}/odoo
-EOF
+    sed -i '1 i\if [ "x${TRAVIS_PYTHON_VERSION}" == "x"  ] ; then\n
+                    \tTRAVIS_PYTHON_VERSION="2.7"\n
+                fi\n
+                source /.repo_requirements/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/activate\n
+                source /.repo_requirements/virtualenv/nodejs/bin/activate\n
+                PYTHONPATH=:/.repo_requirements/odoo\n\n' $BASHRC
 done
 
 # Install Tmux Plugin Manager


### PR DESCRIPTION
Active the virtual environment in the top of the file .`bashrc` because the file `.bashrc` contains the follow sentence
```bash
# If not running interactively, don't do anything
[ -z "$PS1" ] && return
```
and when the gitlab-ci run using this imagen the virtual environment is not load as should be

This change will enable the possibility to use the environment variable `TRAVIS_PYTHON_VERSION` on the build of gitlab-ci