### PR TITLE
[FIX] odoo-shippable: Copy the package apt_pkg from python3.4 to python3.5

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -181,6 +181,7 @@ rm /usr/bin/python3
 ln -s /usr/bin/python3.5 /usr/bin/python3
 rm /usr/local/bin/pip3
 ln -s /usr/local/bin/pip3.5 /usr/local/bin/pip3
+cp /usr/lib/python3/dist-packages/apt_pkg.cpython-34m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.cpython-35m-x86_64-linux-gnu.so
 
 # Creating virtual environments node js
 nodeenv ${REPO_REQUIREMENTS}/virtualenv/nodejs


### PR DESCRIPTION
This change is to avoid the follow mistake

![image](https://user-images.githubusercontent.com/1387970/32126683-06b1b062-bb40-11e7-8a28-d591ea2abb4e.png)

I made the follow test and now the command `apt-add-repository -y "ppa:pov/wkhtmltopdf"` ran well

![image](https://user-images.githubusercontent.com/1387970/32126701-1a0d747a-bb40-11e7-8150-adcb791d8fe7.png)

