### PR TITLE
[FIX] Update branches to 11.0 since that's the proper version we should be using

### DIFF
--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -13,9 +13,9 @@ ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
-ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@master \
-                   git+https://github.com/vauxoo/server-tools@saas-18 \
-                   git+https://github.com/vauxoo/addons-vauxoo@saas-18 \
+ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
+                   git+https://github.com/vauxoo/server-tools@11.0 \
+                   git+https://github.com/vauxoo/addons-vauxoo@11.0 \
                    git+https://github.com/vauxoo/pylint-odoo@master"
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo110/11.0-full_requirements.txt"
 DPKG_DEPENDS="nodejs \


### PR DESCRIPTION
@moylop260 since the 11.0 was released we no longer need to have the saas-18 branch as main dependency source, we should be using 11.0