### PR TITLE
[FIX] odoo-shippable: use virtualenv plugin for zsh and allow prompt elements

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -425,7 +425,7 @@ for BASHRC in ${HOME}/.bashrc /home/odoo/.bashrc ${HOME}/.zshrc /home/odoo/.zshr
 do
     echo "Export the PYTHONPATH IN ${BASHRC}"
     cat >> $BASHRC << EOF
-if [ "x\${TRAVIS_PYTHON_VERSION}" == "x" ] ; then
+if [[ "x\${TRAVIS_PYTHON_VERSION}" == "x" ]] ; then
     TRAVIS_PYTHON_VERSION="2.7"
 fi
 source ${REPO_REQUIREMENTS}/virtualenv/python\${TRAVIS_PYTHON_VERSION}/bin/activate

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -407,7 +407,6 @@ ln -s "${REPO_REQUIREMENTS}/tools" "/home/odoo/tools"
 # Install & configure zsh
 git_clone_execute "${OH_MY_ZSH_REPO}" "master" "tools/install.sh"
 git_clone_copy "${ZSH_THEME_REPO}" "master" "schminitz.zsh-theme" "${HOME}/.oh-my-zsh/themes/odoo-shippable.zsh-theme"
-sed -i 's/robbyrussell/odoo-shippable/g' ~/.zshrc
 
 #Copy zsh for odoo user
 cp -r ${HOME}/.oh-my-zsh /home/odoo
@@ -415,6 +414,9 @@ chown -R odoo:odoo /home/odoo/.oh-my-zsh
 cp ${HOME}/.zshrc /home/odoo/.zshrc
 chown odoo:odoo /home/odoo/.zshrc
 sed -i 's/root/home\/odoo/g' /home/odoo/.zshrc
+sed -i 's/robbyrussell/odoo-shippable/g' /home/odoo/.zshrc
+sed -i 's/^plugins=(/plugins=(\n  virtualenv/' /home/odoo/.zshrc
+
 # Set default shell to the root user
 usermod -s /bin/bash root
 


### PR DESCRIPTION
Just as simply enable `virtualenv` plugin for zsh, showing prompt correctly


## Tested:
```bash
~/d/odoo-shippable git:master-zsh-virtualenv-osval ❯ docker build -f Dockerfile -t vauxoo/zshenv .
Sending build context to Docker daemon  38.91kB
...
Step 7/7 : EXPOSE 5432 8069 8070 8071 8072 22 60000-60005/udp
 ---> Using cache
 ---> 081b4fd58076
Successfully built 081b4fd58076
Successfully tagged vauxoo/zshenv:latest
~/d/odoo-shippable git:master-zsh-virtualenv-osval ❯ docker run -it --name zshenv_test --entrypoint=zsh -e LANG=en_US.UTF-8 -p 3502:8069 -itP 081b4fd58076
WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
(nodejs)(python2.7) ➜  / %                                                                                                                     
~/d/odoo-shippable git:master-zsh-virtualenv-osval ❯ docker exec --user odoo -it zshenv_test bash
(nodejs)(python2.7) [odoo@6ab56809c21e]/$
$ cd
(nodejs)(python2.7) [odoo@6ab56809c21e]~$
$ exit
~/d/odoo-shippable git:master-zsh-virtualenv-osval ❯ docker exec --user odoo -it zshenv_test zsh
(nodejs)
[6:17:31] /
 $ python --version
Python 2.7.12
(nodejs)
[6:17:42] ~
 $
~/d/odoo-shippable git:master-zsh-virtualenv-osval ❯
```