### PR TITLE
[FIX] odoo-shippable: Install the pylint_odoo and the dependencies for each version of python installed

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -48,7 +48,7 @@ TMUX_PLUGINS_REPO="https://github.com/tmux-plugins/tpm"
 DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-contrib-9.5 \
               postgresql-10 postgresql-contrib-10 \
               pgbadger pgtune perl-modules make openssl p7zip-full expect-dev mosh bpython \
-              bsdtar rsync graphviz openssh-server cmake zsh tree tig \
+              bsdtar rsync graphviz openssh-server cmake zsh tree tig libffi-dev \
               lua50 liblua50-dev liblualib50-dev exuberant-ctags rake \
               python3.2 python3.2-dev python3.3 python3.3-dev python3.4 python3.4-dev \
               python3.5 python3.5-dev python3.6 python3.6-dev \
@@ -176,6 +176,7 @@ do
     pip install --force-reinstall --upgrade coverage --src .
 
     # Execute travis_install_nightly
+    echo "Install the linit pip requirements using python${version}"
     LINT_CHECK=1 TESTS=0 ${REPO_REQUIREMENTS}/linit_hook/travis/travis_install_nightly
     pip install --no-binary pycparser -r ${REPO_REQUIREMENTS}/linit_hook/requirements.txt
 

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -173,6 +173,11 @@ do
     # Please don't remove it because emit errors from other environments
     source ${REPO_REQUIREMENTS}/virtualenv/python${version}/bin/activate
     pip install --force-reinstall --upgrade coverage --src .
+
+    # Execute travis_install_nightly
+    LINT_CHECK=1 TESTS=0 ${REPO_REQUIREMENTS}/linit_hook/travis/travis_install_nightly
+    pip install --no-binary pycparser -r ${REPO_REQUIREMENTS}/linit_hook/requirements.txt
+
     deactivate
 done
 export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7
@@ -188,10 +193,6 @@ cp /usr/lib/python3/dist-packages/apt_pkg.cpython-34m-x86_64-linux-gnu.so /usr/l
 # Creating virtual environments node js
 nodeenv ${REPO_REQUIREMENTS}/virtualenv/nodejs
 echo "REPO_REQUIREMENTS=${REPO_REQUIREMENTS}" >> /etc/bash.bashrc
-
-# Execute travis_install_nightly
-LINT_CHECK=1 TESTS=0 ${REPO_REQUIREMENTS}/linit_hook/travis/travis_install_nightly
-pip install --no-binary pycparser -r ${REPO_REQUIREMENTS}/linit_hook/requirements.txt
 
 # Keep alive the ssh server
 #   60 seconds * 360 = 21600 seconds = 6 hours

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -81,6 +81,7 @@ add_custom_aptsource "${VIM_PPA_REPO}" "${VIM_PPA_KEY}"
 add_custom_aptsource "${TMUX_PPA_REPO}" "${TMUX_PPA_KEY}"
 
 # Release the apt monster!
+echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
 apt-get update
 apt-get upgrade
 apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}


### PR DESCRIPTION
This change install all `lint` requirements in all `python` version installed, to avoid mistake related with `.git/hooks/pre-commit`

This change can be tester with the follow step 
- Clone this branch
- Build the imagen with the follow command `docker build -t lint_fix odoo-shippable/.`
- Made a t2d command using the previous imagen generated using one test repository ` t2d --docker-image=lint_fix git@github.com:JesusZapata/asdcust.git 11.0`
- Inside the container run the `.git/hooks/pre-commit` 


Fix https://github.com/Vauxoo/maintainer-quality-tools/issues/258