### PR TITLE
[ADD] odoo110: dependencies required to implement multi website

### DIFF
--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -50,7 +50,13 @@ DPKG_DEPENDS="nodejs \
               postgresql-${PSQL_VERSION} \
               postgresql-client-${PSQL_VERSION} \
               postgresql-contrib-${PSQL_VERSION} \
-              pgbadger"
+              pgbadger \
+              ruby-dev \
+              ruby-compass \
+              autoconf \
+              automake \
+              libtool \
+              libltdl-dev"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \
@@ -66,6 +72,9 @@ PIP_DEPENDS_EXTRA="reqgen \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
 
 PIP_DPKG_BUILD_DEPENDS=""
+
+RUBY_DEPENDS="compass \
+              bootstrap-sass"
 
 # Let's add the NodeJS upstream repo to install a newer version
 add_custom_aptsource "${NODE_UPSTREAM_REPO}" "${NODE_UPSTREAM_KEY}"
@@ -92,6 +101,9 @@ pip3 install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 
 # Install qt patched version of wkhtmltopdf because of maintainer nonsense
 wkhtmltox_install "${WKHTMLTOX_URL}"
+
+# Install ruby dependencies
+gem install ${RUBY_DEPENDS}
 
 # Remove build depends for pip
 apt-get purge ${PIP_DPKG_BUILD_DEPENDS} ${DPKG_UNNECESSARY}


### PR DESCRIPTION
These dependencies are needed in order to implement multi website.  
According to [this](https://github.com/it-projects-llc/website-addons/blob/11.0/website_multi_company/doc/index.rst), we need the following dependencies:  
- apt:  
  - ruby-compass
- gem:  
  - compass
  - bootstrap-sass

In order to install those dependencies, we also need:   
- apt:   
  - ruby-dev, fixes:  
![image](https://user-images.githubusercontent.com/12100691/36122390-ca2bc050-100e-11e8-89e5-3c11cc3d8854.png)   
  - autoconf, fixes:  
![image](https://user-images.githubusercontent.com/12100691/36122437-ea5d24ae-100e-11e8-8d4c-d4e83cdf1288.png)   
  - automake, fixes:  
![image](https://user-images.githubusercontent.com/12100691/36122492-1e14a84e-100f-11e8-8d13-e2bf6e4b4da9.png)  
  - libtool, fixes:   
![image](https://user-images.githubusercontent.com/12100691/36122522-410e3a22-100f-11e8-83fb-ab0363ab822a.png)  
  - libltdl-dev, fixes:  
![image](https://user-images.githubusercontent.com/12100691/36122561-6d86f44a-100f-11e8-9d4c-64a4f1975f8d.png)


After all these dependencies were installed, I was able to install `compass` and `bootstrap-sass` using gem.

