### PR TITLE
[FIX] Removed mercurial fromthis build because is already installed i…

### DIFF
--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -63,11 +63,9 @@ NPM_DEPENDS="less \
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
-                   mercurial==3.2.2 \
                    setuptools==33.1.1 \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
-                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
-                   hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
+                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc"
 
 PIP_DPKG_BUILD_DEPENDS=""
 


### PR DESCRIPTION
…n the ubuntu base image.

Mercurial is being installed here: https://github.com/Vauxoo/docker-ubuntu-base/blob/master/scripts/build-image.sh#L20

Also after upgrading pip to 10.0 is showing this error durig the build process:

*Cannot uninstall 'mercurial'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.*

@moylop260 