### PR TITLE
[IMP] 11.0: Specific the version that work in Odoo

### DIFF
--- a/odoo110/scripts/11.0-full_requirements.txt
+++ b/odoo110/scripts/11.0-full_requirements.txt
@@ -1,3 +1,4 @@
 ofxparse
 cython
 boto3
+python-stdnum==1.8.1


### PR DESCRIPTION
The lib was updated the last Apr 14, and the method `country_codes` was
renamed by `country_codes`. Odoo calls the last method

Now: https://github.com/arthurdejong/python-stdnum/blob/d9defc8b514e5f2d9c545de23054e416bd7bd2ab/stdnum/eu/vat.py#L46
After: https://github.com/arthurdejong/python-stdnum/blame/9841baec64391567d70f2fe6c0f8a58cc27a4eee/stdnum/eu/vat.py#L46

https://github.com/odoo/odoo/blob/11.0/addons/base_vat_autocomplete/models/res_partner.py#L52

Hoy this library, is nos added in the repo requirements, but is a
depends to vatnumber.

I define the stable version that work with Odoo.