### PR TITLE
[IMP] odoo-shippable: install by default aspell

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -53,7 +53,8 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
               python3.2 python3.2-dev python3.3 python3.3-dev python3.4 python3.4-dev \
               python3.5 python3.5-dev python3.6 python3.6-dev \
               software-properties-common Xvfb libmagickwand-dev openjdk-7-jre \
-              dos2unix subversion tmux=2.0-1~ppa1~t"
+              dos2unix subversion tmux=2.0-1~ppa1~t \
+              aspell aspell-es"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="line-profiler watchdog coveralls diff-highlight \


### PR DESCRIPTION
This installs GNU Aspell by default, which is an useful spell checker.