### PR TITLE
[IMP] odoo-shippable: Install the English dictionary for Aspell

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -54,7 +54,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
               python3.5 python3.5-dev python3.6 python3.6-dev \
               software-properties-common Xvfb libmagickwand-dev openjdk-7-jre \
               dos2unix subversion tmux=2.0-1~ppa1~t \
-              aspell aspell-es"
+              aspell aspell-en aspell-es"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="line-profiler watchdog coveralls diff-highlight \


### PR DESCRIPTION
When GNU Aspell is installed, it does not install any dictionary by
default. Currently, only the Spanish dictionary is being installed.

This causes the English dictionary to be also installed.