### PR TITLE
[IMP] odoo-shippable: Apply VX's custom config for all PostgreSQL

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -473,11 +473,6 @@ if [ -f ~/.bash_aliases ]; then
 fi
 EOF
 
-# Set custom configuration of max connections, port and locks for postgresql
-sed -i 's/#max_pred_locks_per_transaction = 64/max_pred_locks_per_transaction = 100/g' /etc/postgresql/*/main*/postgresql.conf
-sed -i 's/max_connections = 100/max_connections = 200/g' /etc/postgresql/*/main*/postgresql.conf
-sed -i 's/^port = .*/port = 5432/g' /etc/postgresql/*/main*/postgresql.conf
-
 # Overwrite get_versions function to avoid overwriting the init script
 # See https://github.com/vauxoo/docker-odoo-image/issues/114 for details
 cat >> /usr/share/postgresql-common/init.d-functions << 'EOF'
@@ -516,10 +511,6 @@ PSQL_VERSION="10" /entrypoint_image
 psql_create_role "shippable" "aeK5NWNr2"
 psql_create_role "root" "aeK5NWNr2"
 /etc/init.d/postgresql stop
-
-
-# Enable PG LOGS AND NON DURABILITY
-PG_NON_DURABILITY=1 PG_LOGS_ENABLE=1 python ${REPO_REQUIREMENTS}/linit_hook/travis/psql_log.py
 
 # Install & Configure RVM
 curl -sSL https://rvm.io/mpapis.asc | gpg --import -

--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -68,10 +68,11 @@ service_postgres_without_sudo(){
     chown -R ${USER}:postgres /var/run/postgresql
     for version in $VERSIONS; do
         pg_createcluster -u ${USER} -g postgres -s /var/run/postgresql -p 15432 --start-conf auto --start $version main
+        echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/version/main/postgresql.conf
         su - ${USER} -c "psql -p 15432 -d postgres -c  \"ALTER ROLE ${USER} WITH PASSWORD 'aeK5NWNr2';\""
         su - ${USER} -c "psql -p 15432 -d postgres -c  \"CREATE ROLE postgres LOGIN SUPERUSER INHERIT CREATEDB CREATEROLE;\""
         /etc/init.d/postgresql stop $version
         sed -i "s/port = 15432/port = 5432/g" /etc/postgresql/$version/main/postgresql.conf
     done
-    
+
 }


### PR DESCRIPTION
Currently, custom settings for PostgreSQL, available on the image
`docker-ubuntu-base`, were not applied in the big image. One of the
consequences of that is the parameter `autovacuum` was not being
disabled.

This causes the Vauxoo's custom tune-ups to be applied in the big image,
for all installed versions.

Closes #305