### PR TITLE
[FIX] odoo-shippable: Solve issues after dropped support of Python3.3

### DIFF
--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -68,7 +68,7 @@ service_postgres_without_sudo(){
     chown -R ${USER}:postgres /var/run/postgresql
     for version in $VERSIONS; do
         pg_createcluster -u ${USER} -g postgres -s /var/run/postgresql -p 15432 --start-conf auto --start $version main
-        echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/version/main/postgresql.conf
+        echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/$version/main/postgresql.conf
         su - ${USER} -c "psql -p 15432 -d postgres -c  \"ALTER ROLE ${USER} WITH PASSWORD 'aeK5NWNr2';\""
         su - ${USER} -c "psql -p 15432 -d postgres -c  \"CREATE ROLE postgres LOGIN SUPERUSER INHERIT CREATEDB CREATEROLE;\""
         /etc/init.d/postgresql stop $version


### PR DESCRIPTION
This applies the following fixes, mostly related to issues due to
dropped support for Python3.3:
- Freeze virtualenv version: Starting from version 16.0, virtualenv is
  not compatible with Python 3.3 anymore. Therefore, the virtualenv
  version needs to be freezed for that Python version.
- Don't install virtualenv twice: virtualenv was being installed again
  when creating environments for all Python versions
- Print messages when installing pip for all versions
- Fix small typos in messages printed when creating virtualenvironments
- Add a missing `$` character in the library (my bad)
- Remove redundant parameter `-p` when creating virtualenvs
- Install all Odoo versions from Vauxoo and Odoo; V11 was not being
  installed

Closes #309