### PR TITLE
[IMP] odoo-shippable: Add gettext as a dependency

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -54,7 +54,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-co
               python3.5 python3.5-dev python3.6 python3.6-dev \
               software-properties-common Xvfb libmagickwand-dev openjdk-7-jre \
               dos2unix subversion tmux=2.0-1~ppa1~t \
-              aspell aspell-en aspell-es"
+              aspell aspell-en aspell-es gettext"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="line-profiler watchdog coveralls diff-highlight \


### PR DESCRIPTION
Since MQT now requires click-odoo-makepot to construct .pot files, and
this last uses `msgmerge` to merge translation messages,  we need to add
gettext as a dependency, which provides that commandthe required command

This is one more step to solve  https://github.com/Vauxoo/maintainer-quality-tools/issues/265