### PR TITLE
[REF] odoo-shippable: Use by default postgresql 9.6 instead of 9.3

### DIFF
--- a/odoo-shippable/Dockerfile
+++ b/odoo-shippable/Dockerfile
@@ -2,7 +2,7 @@ FROM vauxoo/odoo-80-image
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
 ENV RUN_COMMAND_MQT_10_ENTRYPOINT_IMAGE="/entrypoint_image" \
-    INSTANCE_ALIVE="1" PSQL_VERSION="9.3" \
+    INSTANCE_ALIVE="1" PSQL_VERSION="9.6" \
     REPO_REQUIREMENTS="/.repo_requirements" \
     WITHOUT_DEPENDENCIES="1" OCA_RUNBOT="1" \
     REPO_CACHED="/.repo_requirements"

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -489,7 +489,7 @@ get_versions() {
         if [ -n "${PSQL_VERSION}" ]; then
             versions="${PSQL_VERSION}"
         else
-            versions="9.3"
+            versions="9.6"
         fi
     fi
 }


### PR DESCRIPTION
* 9.3 is too old and odoo has errors related with older PostgreSQL versions
  - Similar to https://github.com/OCA/maintainer-quality-tools/issues/432#issuecomment-281580935
* PostgreSQL 9.3 is not supporting 'max_wal_size' configuration parameter.
  - It parameter is required to configure a non-durability PostgreSQL
    More info about: https://www.postgresql.org/docs/10/static/non-durability.html
* PostgreSQL 9.3 is not supporting `INSERT INTO ... ON CONFLICT DO NOTHING`

Fix https://github.com/Vauxoo/docker-odoo-image/issues/315