### PR TITLE
[FIX] build.py: Avoid false positives when build fails

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,7 +57,7 @@ class DockerOdooImages(object):
                    "--build-arg", "IS_TRAVIS=%s" % is_travis,
                    "--rm", "-t", self._docker_image, self._folder]
             print " ".join(cmd)
-            subprocess.call(cmd)
+            return subprocess.call(cmd)
         return 0
 
 


### PR DESCRIPTION
Before this commit, the return value of the command `docker build` was
not being taken into account, thus producing false positives when the
build failed.

After this commit, the return value is taken into account and it's
returned, causing the script to return a non-zero value when the build
command returns a non-zero value.