### PR TITLE
[REF] odoo-shippable: py3.7 stuffs

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -141,13 +141,6 @@ do
     echo "Install all pip dependencies for python${version}"
     collect_pip_dependencies "${ODOO_DEPENDENCIES_PY3}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"
     clean_requirements ${DEPENDENCIES_FILE}
-    if [ $version == "3.7" ]; then
-        # Use compatible versions with py37
-        sed -i "/greenlet/d" ${DEPENDENCIES_FILE}
-        sed -i "/lxml/d" ${DEPENDENCIES_FILE}
-        sed -i "/gevent/d" ${DEPENDENCIES_FILE}
-        echo -e "greenlet==0.4.13\nlxml==4.1.1\ngevent==1.3.5" >> ${DEPENDENCIES_FILE}
-    fi
     python"$version" -m pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 done
 

--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -208,6 +208,10 @@ do
 
     deactivate
 done
+
+# Add python3.7-dev for compatibility with travis.yml
+ln -s ${REPO_REQUIREMENTS}/virtualenv/python3.7 ${REPO_REQUIREMENTS}/virtualenv/python3.7-dev
+
 export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7
 echo "VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7" >> /etc/bash.bashrc
 


### PR DESCRIPTION
* [REF] odoo-shippable: Add link symbolic python3.7-dev virtual environment for compatibility with travis.yml

    https://docs.travis-ci.com/user/languages/python/#Specifying-Python-versions

* [REF] odoo-shippable: Remove custom version for 3.7

    Fixed from https://github.com/odoo/odoo/pull/25841