### PR TITLE
[IMP] Updatre wkhtmltopdf from 0.12.4 to 0.12.5

### DIFF
--- a/odoo120/scripts/build-image.sh
+++ b/odoo120/scripts/build-image.sh
@@ -10,7 +10,7 @@ set -e
 . /etc/lsb-release
 # Let's set some defaults here
 ARCH="$( dpkg --print-architecture )"
-WKHTMLTOX_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
+WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
 DPKG_DEPENDS="nodejs \
               npm \
               antiword \
@@ -50,7 +50,9 @@ DPKG_DEPENDS="nodejs \
               automake \
               libtool \
               libltdl-dev \
-              libcups2-dev"
+              libcups2-dev \
+              xfonts-75dpi \
+              xfonts-base"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="phantomjs-prebuilt \

--- a/odoo120/scripts/library.sh
+++ b/odoo120/scripts/library.sh
@@ -50,7 +50,7 @@ open('$1', 'w').writelines('\n'.join(req2))"
 function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
-    wget -qO- "${URL}" | tar -xJ -C "${DIR}/"
-    mv "${DIR}/wkhtmltox/bin/wkhtmltopdf" "/usr/local/bin/wkhtmltopdf"
+    wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
+    dpkg -i "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }


### PR DESCRIPTION
The logic to install wkhtmltopdf was changed because they didn't [packaged the xz](https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.5) and they packaged a .deb, so just used it.