### PR TITLE
[FIX] Use dependencies from pip instead of the ones from apt to avoid erros

### DIFF
--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -42,7 +42,6 @@ DPKG_DEPENDS="nodejs \
               libxml2-dev \
               libxslt1-dev \
               libgeoip-dev \
-              cython \
               fontconfig \
               ghostscript \
               cloc \
@@ -60,7 +59,6 @@ PIP_OPTS="--upgrade \
           --no-cache-dir"
 
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
-                   mercurial==3.2.2 \
                    setuptools==33.1.1 \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
                    git+https://github.com/vauxoo/panama-dv@master#egg=ruc \

--- a/odoo120/scripts/build-image.sh
+++ b/odoo120/scripts/build-image.sh
@@ -10,9 +10,11 @@ set -e
 . /etc/lsb-release
 # Let's set some defaults here
 ARCH="$( dpkg --print-architecture )"
+NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_8.x trusty main"
+NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
+PHANTOMJS_VERSION="2.1.1"
 DPKG_DEPENDS="nodejs \
-              npm \
               antiword \
               python3-dev \
               poppler-utils \
@@ -55,8 +57,7 @@ DPKG_DEPENDS="nodejs \
               xfonts-base"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
-NPM_DEPENDS="phantomjs-prebuilt \
-             less \
+NPM_DEPENDS="less \
              less-plugin-clean-css \
              jshint"
 PIP_OPTS="--upgrade \
@@ -73,7 +74,7 @@ RUBY_DEPENDS="compass \
               bootstrap-sass"
 
 # Let's add the NodeJS upstream repo to install a newer version
-#add_custom_aptsource "${NODE_UPSTREAM_REPO}" "${NODE_UPSTREAM_KEY}"
+add_custom_aptsource "${NODE_UPSTREAM_REPO}" "${NODE_UPSTREAM_KEY}"
 
 # Release the apt monster!
 apt-get update
@@ -92,6 +93,8 @@ pip3 install ${PIP_OPTS} ${PIP_DEPENDS_EXTRA}
 
 # Install qt patched version of wkhtmltopdf because of maintainer nonsense
 wkhtmltox_install "${WKHTMLTOX_URL}"
+
+phantomjs_install "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"
 
 # Install ruby dependencies
 gem install ${RUBY_DEPENDS}

--- a/odoo120/scripts/library.sh
+++ b/odoo120/scripts/library.sh
@@ -54,3 +54,14 @@ function wkhtmltox_install(){
     dpkg -i "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
+
+function phantomjs_install(){
+    URL="${1}"
+    DIR="$( mktemp -d )"
+    wget -qO "${DIR}/phantomjs.tar.bz2" "${URL}"
+    mkdir -p "${DIR}/phantomjs"
+    tar xvjf "${DIR}/phantomjs.tar.bz2" -C "${DIR}/phantomjs/" --strip-components=1
+    mv "${DIR}/phantomjs/" /usr/local/share
+    ln -sf /usr/local/share/phantomjs/bin/phantomjs /usr/local/bin
+    rm -rf "${DIR}"
+}


### PR DESCRIPTION

[FIX] Proper phantom and node.

- Phantomjs intallation was failing so instead of using the one from apt install the one from the proper origin.
- Nodejs is failing in Ubuntu 18.04 so install the node repository and use the same LTS version from there (v 8.x)

The package versions are the same, but we changed the origin only. All this was needed to update all the images because a lot of packages had security issues.

@moylop260 This is the second part of the fix mentioned [here](https://github.com/Vauxoo/docker-ubuntu-base/pull/51#issuecomment-438761577)