### PR TITLE
[IMP] Add GeoipLite City

### DIFF
--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -18,6 +18,7 @@ ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@11.0 \
                    git+https://github.com/vauxoo/pylint-odoo@master"
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo110/11.0-full_requirements.txt"
+GEOIP_DB_URL="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz"
 DPKG_DEPENDS="nodejs \
               phantomjs \
               antiword \
@@ -102,6 +103,9 @@ pip3 install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
 
 # Install qt patched version of wkhtmltopdf because of maintainer nonsense
 wkhtmltox_install "${WKHTMLTOX_URL}"
+
+# Install GeoIP database
+geoip_install "${GEOIP_DB_URL}"
 
 # Install ruby dependencies
 gem install ${RUBY_DEPENDS}

--- a/odoo110/scripts/library.sh
+++ b/odoo110/scripts/library.sh
@@ -104,3 +104,11 @@ function wkhtmltox_install(){
     mv "${DIR}/wkhtmltox/bin/wkhtmltopdf" "/usr/local/bin/wkhtmltopdf"
     rm -rf "${DIR}"
 }
+
+function geoip_install(){
+    URL="${1}"
+    DIR="$( mktemp -d )"
+    wget -qO- "${URL}" | tar -xz -C "${DIR}/"
+    mv "$(find ${DIR} -name "GeoLite2-City.mmdb")" "/usr/share/GeoIP/GeoLite2-City.mmdb"
+    rm -rf "${DIR}"
+}


### PR DESCRIPTION
This is the dabatase file needed for GeoIP in Odoo 11.0, it is added in the default path as shown [here](https://github.com/Vauxoo/odoo/blob/11.0/odoo/tools/config.py#L277) to avoid any configuration in the instances so it'll be automatically available

