### PR TITLE
[REF] docker-odoo-image: don't install postgres in the base images

### DIFF
--- a/odoo100/Dockerfile
+++ b/odoo100/Dockerfile
@@ -1,6 +1,5 @@
 FROM vauxoo/docker-ubuntu-base:16.04
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
-ENV PSQL_VERSION="9.6"
 COPY scripts/* /usr/share/vx-docker-internal/odoo100/
 RUN bash /usr/share/vx-docker-internal/odoo100/build-image.sh

--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -46,12 +46,7 @@ DPKG_DEPENDS="nodejs \
               libgeoip-dev \
               fontconfig \
               ghostscript \
-              cloc \
-              postgresql-common \
-              postgresql-${PSQL_VERSION} \
-              postgresql-client-${PSQL_VERSION} \
-              postgresql-contrib-${PSQL_VERSION} \
-              pgbadger"
+              cloc"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \
@@ -105,5 +100,3 @@ rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf
 find /var/log -type f -print0 | xargs -0r rm -rf
 find /var/lib/apt/lists -type f -print0 | xargs -0r rm -rf
-echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/${PSQL_VERSION}/main/postgresql.conf
-echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/$PSQL_VERSION/main/pg_hba.conf

--- a/odoo110/Dockerfile
+++ b/odoo110/Dockerfile
@@ -1,6 +1,5 @@
 FROM vauxoo/docker-ubuntu-base:16.04-p3
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
-ENV PSQL_VERSION="9.6"
 COPY scripts/* /usr/share/vx-docker-internal/odoo110/
 RUN bash /usr/share/vx-docker-internal/odoo110/build-image.sh

--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -49,11 +49,6 @@ DPKG_DEPENDS="nodejs \
               fontconfig \
               ghostscript \
               cloc \
-              postgresql-common \
-              postgresql-${PSQL_VERSION} \
-              postgresql-client-${PSQL_VERSION} \
-              postgresql-contrib-${PSQL_VERSION} \
-              pgbadger \
               ruby-dev \
               ruby-compass \
               autoconf \
@@ -134,5 +129,3 @@ rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf
 find /var/log -type f -print0 | xargs -0r rm -rf
 find /var/lib/apt/lists -type f -print0 | xargs -0r rm -rf
-echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/${PSQL_VERSION}/main/postgresql.conf
-echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/$PSQL_VERSION/main/pg_hba.conf

--- a/odoo120/Dockerfile
+++ b/odoo120/Dockerfile
@@ -1,6 +1,5 @@
 FROM vauxoo/docker-ubuntu-base:18.04
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
-ENV PSQL_VERSION="9.6"
 COPY scripts/* /usr/share/vx-docker-internal/odoo120/
 RUN bash /usr/share/vx-docker-internal/odoo120/build-image.sh

--- a/odoo120/scripts/build-image.sh
+++ b/odoo120/scripts/build-image.sh
@@ -43,11 +43,6 @@ DPKG_DEPENDS="nodejs \
               fontconfig \
               ghostscript \
               cloc \
-              postgresql-common \
-              postgresql-${PSQL_VERSION} \
-              postgresql-client-${PSQL_VERSION} \
-              postgresql-contrib-${PSQL_VERSION} \
-              pgbadger \
               ruby-dev \
               ruby-compass \
               autoconf \
@@ -116,5 +111,3 @@ rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf
 find /var/log -type f -print0 | xargs -0r rm -rf
 find /var/lib/apt/lists -type f -print0 | xargs -0r rm -rf
-echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/${PSQL_VERSION}/main/postgresql.conf
-echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/$PSQL_VERSION/main/pg_hba.conf

--- a/odoo80/Dockerfile
+++ b/odoo80/Dockerfile
@@ -1,6 +1,5 @@
 FROM vauxoo/docker-ubuntu-base:latest
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
-ENV PSQL_VERSION="9.6"
 COPY scripts/* /usr/share/vx-docker-internal/odoo80/
 RUN bash /usr/share/vx-docker-internal/odoo80/build-image.sh

--- a/odoo80/scripts/build-image.sh
+++ b/odoo80/scripts/build-image.sh
@@ -48,11 +48,6 @@ DPKG_DEPENDS="nodejs \
               fontconfig \
               ghostscript \
               cloc \
-              postgresql-common \
-              postgresql-${PSQL_VERSION} \
-              postgresql-client-${PSQL_VERSION} \
-              postgresql-contrib-${PSQL_VERSION} \
-              postgresql-server-dev-${PSQL_VERSION} \
               pgbadger \
               python-cups"
 DPKG_UNNECESSARY=""
@@ -104,5 +99,3 @@ rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf
 find /var/log -type f -print0 | xargs -0r rm -rf
 find /var/lib/apt/lists -type f -print0 | xargs -0r rm -rf
-echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/${PSQL_VERSION}/main/postgresql.conf
-echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/$PSQL_VERSION/main/pg_hba.conf

--- a/odoo90/Dockerfile
+++ b/odoo90/Dockerfile
@@ -1,7 +1,6 @@
 FROM vauxoo/docker-ubuntu-base:latest
 MAINTAINER Tulio Ruiz <tulio@vauxoo.com>
 
-ENV PSQL_VERSION="9.6"
 COPY scripts/* /usr/share/vx-docker-internal/odoo90/
 COPY files/hgrc /root/.hgrc
 RUN bash /usr/share/vx-docker-internal/odoo90/build-image.sh

--- a/odoo90/scripts/build-image.sh
+++ b/odoo90/scripts/build-image.sh
@@ -49,13 +49,7 @@ DPKG_DEPENDS="nodejs \
               cython \
               fontconfig \
               ghostscript \
-              cloc \
-              postgresql-common \
-              postgresql-${PSQL_VERSION} \
-              postgresql-client-${PSQL_VERSION} \
-              postgresql-contrib-${PSQL_VERSION} \
-              postgresql-server-dev-${PSQL_VERSION} \
-              pgbadger"
+              cloc"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \
@@ -107,5 +101,3 @@ rm -rf /tmp/*
 find /var/tmp -type f -print0 | xargs -0r rm -rf
 find /var/log -type f -print0 | xargs -0r rm -rf
 find /var/lib/apt/lists -type f -print0 | xargs -0r rm -rf
-echo "include = '/etc/postgresql-common/common-vauxoo.conf'" >> /etc/postgresql/${PSQL_VERSION}/main/postgresql.conf
-echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/$PSQL_VERSION/main/pg_hba.conf


### PR DESCRIPTION
Since we need to control which postgres versions will be installed in the customer's instances, we will remove the installation of the postgres packages from the base image and will install them in deployv.

More info:  https://git.vauxoo.com/vauxoo/deployv/merge_requests/487