### PR TITLE
[FIX] Fix error during build with ruby dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo90 --docker-image vauxoo/odoo-90-image:latest
   - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo100 --docker-image vauxoo/odoo-100-image:latest
   - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo110 --docker-image vauxoo/odoo-110-image:latest
+  - python ${TRAVIS_BUILD_DIR}/build.py --folder ${TRAVIS_BUILD_DIR}/odoo120 --docker-image vauxoo/odoo-120-image:latest
   - docker run -it --rm --name fix-vim-snippet -v ${TRAVIS_BUILD_DIR}/odoo-shippable/scripts/fix-vim-snippet.py:/root/fix-vim-snippet.py vauxoo/odoo-80-image-shippable-auto python /root/fix-vim-snippet.py --extensions sh,sql,python
 
 after_success:

--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -13,6 +13,7 @@ ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
+RUBY_VERSION="2.5.3"
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
                    git+https://github.com/vauxoo/server-tools@11.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@11.0 \
@@ -58,7 +59,14 @@ DPKG_DEPENDS="nodejs \
               automake \
               libtool \
               libltdl-dev \
-              libcups2-dev"
+              libcups2-dev \
+              libgdbm-dev \
+              libncurses5-dev \
+              bison \
+              libffi-dev \
+              gnupg2 \
+              dirmngr"
+
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
 NPM_DEPENDS="less \
@@ -106,6 +114,12 @@ wkhtmltox_install "${WKHTMLTOX_URL}"
 
 # Install GeoIP database
 geoip_install "${GEOIP_DB_URL}"
+
+# Install Ruby
+update_ruby ${RUBY_VERSION}
+
+# Force install rake before dependencies
+gem install rake
 
 # Install ruby dependencies
 gem install ${RUBY_DEPENDS}

--- a/odoo110/scripts/library.sh
+++ b/odoo110/scripts/library.sh
@@ -112,3 +112,13 @@ function geoip_install(){
     mv "$(find ${DIR} -name "GeoLite2-City.mmdb")" "/usr/share/GeoIP/GeoLite2-City.mmdb"
     rm -rf "${DIR}"
 }
+
+function update_ruby(){
+    RUBY_VERSION="${1}"
+    gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    curl -sSL https://get.rvm.io | bash -s stable
+    sed -i '$a source /etc/profile.d/rvm.sh' /etc/bash.bashrc
+    source /etc/profile.d/rvm.sh
+    rvm install "${RUBY_VERSION}"
+    rvm use "${RUBY_VERSION}" --default
+}

--- a/odoo120/scripts/build-image.sh
+++ b/odoo120/scripts/build-image.sh
@@ -96,6 +96,9 @@ wkhtmltox_install "${WKHTMLTOX_URL}"
 
 phantomjs_install "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2"
 
+# Force install rake before dependencies
+gem install rake
+
 # Install ruby dependencies
 gem install ${RUBY_DEPENDS}
 


### PR DESCRIPTION
This fixes the [error during the builds](https://cloud.docker.com/u/vauxoo/repository/registry-1.docker.io/vauxoo/odoo-120-image/hub-builddetail/brszt7tpzsxnztkhfgoij68) acconrding to [this comment](https://askubuntu.com/a/874551)

This should fix the error in the 11.0 image too:

![a](http://screenshots.vauxoo.com/tulio/11443136118-s4ljUnyTt4.jpg)

- Added build for the 12.0
- Install ruby 2.5.3 in tne image for Odoo 11 using RVM and it will be available for all users (via /etc/bash.bashrc) using [this guide](https://gorails.com/setup/ubuntu/16.04#ruby-rvm) and the recomended version
- Install recomended dependencies for Ruby
- Fix the issue with gpg keys: "gpg: keyserver receive failed: No dirmngr" and the one related to old gpg version (no we use gpg2 for the keys)


