### PR TITLE
[FIX] odoo-shippable: Fix installation py3.7

### DIFF
--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -84,7 +84,7 @@ install_py37(){
     wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
     && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
     && gpg --batch --verify python.tar.xz.asc python.tar.xz \
     && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
     && rm -rf "$GNUPGHOME" python.tar.xz.asc \


### PR DESCRIPTION
Based on https://github.com/docker-library/python/commit/39c500cc8aefcb67a76d518d789441ef85fc771f#diff-ff1457e3a18eea607302812f70d21239

Fix the following error:
```bash
--2019-01-22 03:14:59-- https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tar.xz.asc
Resolving www.python.org (www.python.org)...
151.101.248.223, 2a04:4e42:3b::223
Connecting to www.python.org (www.python.org)|151.101.248.223|:443...
connected.
HTTP request sent, awaiting response...
200 OK
Length: 833 [application/octet-stream]
Saving to: ‘python.tar.xz.asc’
0K 100% 169M=0s
2019-01-22 03:14:59 (169 MB/s) - ‘python.tar.xz.asc’ saved [833/833]
gpg: keyring `/tmp/tmp.aL5HvB2O5M/secring.gpg' created
gpg: keyring `/tmp/tmp.aL5HvB2O5M/pubring.gpg' created
gpg: requesting key AA65421D from hkp server ha.pool.sks-keyservers.net
gpgkeys: key 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D can't be retrieved
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```