### PR TITLE
[FIX] Fix psql install and gpg keys retreival.

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -42,7 +42,9 @@ MQT_REPO="https://github.com/vauxoo/maintainer-quality-tools.git"
 GIST_VAUXOO_REPO="https://github.com/vauxoo-dev/gist-vauxoo.git"
 PYLINT_REPO="https://github.com/vauxoo/pylint-conf.git"
 
-DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 postgresql-9.5 postgresql-contrib-9.5 \
+DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
+              postgresql-9.5 postgresql-contrib-9.5 \
+              postgresql-9.6 postgresql-contrib-9.6 \
               postgresql-10 postgresql-contrib-10 \
               postgresql-11 postgresql-contrib-11 \
               pgbadger pgtune perl-modules make openssl p7zip-full expect-dev mosh bpython \

--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -84,6 +84,9 @@ install_py37(){
     wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
     && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
+    && (gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys --recv-keys "$GPG_KEY" \
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys --recv-keys "$GPG_KEY" ) \
     && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
     && gpg --batch --verify python.tar.xz.asc python.tar.xz \
     && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \


### PR DESCRIPTION
- Psql 9.6 start was failing because it was removed from the base imabe since we will install the customer version that is in the vars file: https://github.com/Vauxoo/docker-odoo-image/commit/c29ca5db96e40e6e82debc71ecaaaea98770a739
- Added another 2 addresses to download the gpg keys, if one failt it should fallback to another. Hopefuly won't fail the 3