### PR TITLE
[FIX] Install mx-egenix-base directrly from pypi

### DIFF
--- a/odoo100/scripts/10.0-full_requirements.txt
+++ b/odoo100/scripts/10.0-full_requirements.txt
@@ -11,7 +11,6 @@ pylint-mccabe
 PyWebDAV
 mygengo
 recaptcha-client
-egenix-mx-base
 branchesv
 pstats_print2list
 pandas>=0.16.2

--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -21,6 +21,7 @@ DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo100/10.0-full_requirements.
 GEOIP2_URLS="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
              https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
              https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
+EGENIX_BASE_URL="https://files.pythonhosted.org/packages/66/e6/e0709aedeb4a5c92a1aeb8c47ab50e9506eafc865806801bd3f01d72b671/egenix-mx-base-3.2.9.zip"
 DPKG_DEPENDS="nodejs \
               phantomjs \
               antiword \
@@ -90,6 +91,8 @@ wkhtmltox_install "${WKHTMLTOX_URL}"
 
 # Install GeoIP database
 geoip_install "${GEOIP2_URLS}"
+
+egenixbase_install "${EGENIX_BASE_URL}"
 
 # Remove build depends for pip
 apt-get purge ${PIP_DPKG_BUILD_DEPENDS} ${DPKG_UNNECESSARY}

--- a/odoo100/scripts/library.sh
+++ b/odoo100/scripts/library.sh
@@ -115,3 +115,12 @@ function geoip_install(){
     done
     rm -rf "${DIR}"
 }
+
+function egenixbase_install(){
+    URL="${1}"
+    DIR="$( mktemp -d )"
+    cd ${DIR}
+    wget -qO egenixbase.zip "${URL}"
+    ls -lah
+    unzip egenixbase.zip && cd "egenix-mx-base-3.2.9" && python setup.py install 
+}


### PR DESCRIPTION
@moylop260 This should fix the errors from [here](https://github.com/Vauxoo/docker-ubuntu-base/pull/55) it seems that an update in unzip or gcc (I'm not sure wich one, but it seems to be unzip).

Also I didn't find any 10.0 instance that use egenix which is not updated since 2015:

![image](https://user-images.githubusercontent.com/2739530/53909161-ad274180-4016-11e9-96b5-f47aa8059ccb.png)

\cc @keylor2906 