### PR TITLE
[FIX] Cannot load GeoIP: Invalid GeoIP database: '/usr/share/GeoIP/GeoLite2-City.mmdb'

### DIFF
--- a/odoo100/scripts/10.0-full_requirements.txt
+++ b/odoo100/scripts/10.0-full_requirements.txt
@@ -2,7 +2,7 @@ fdb==1.7
 sqlalchemy==1.1.9
 pillow-pil
 M2Crypto
-GeoIP
+geoip2
 SOAPpy
 suds
 xmltodict


### PR DESCRIPTION
This is only shown in 10.0 and saas-14 instances, all others seems to be working just fine:

![a](http://screenshots.vauxoo.com/tulio/10423117819-odTaKkpDTG.jpg)

![b](http://screenshots.vauxoo.com/tulio/10430117819-pMbpbuxX8X.jpg)

This will fix it (tested in imeqmo test instance)