### PR TITLE
[FIX] Change pandas and numpy versions.

### DIFF
--- a/odoo80/scripts/8.0-full_requirements.txt
+++ b/odoo80/scripts/8.0-full_requirements.txt
@@ -17,8 +17,8 @@ suds
 num2words
 xlrd>=1.0.0
 IPy
+numpy==1.16.3
 unidecode
-pandas==0.18.0
 cssutils >= 1.0.1
 pyotp==2.0.1
 python-stdnum==1.1


### PR DESCRIPTION
The latest numpy version is not compatible with p2, the support was removed in 1.17.0: https://github.com/numpy/numpy/pull/12506
Also removed the pandas package from full requirements so it use the one from addons-vauxoo: https://github.com/Vauxoo/addons-vauxoo/blob/8.0/requirements.txt\#L1