### PR TITLE
[REF] odoo-shippable: Install 'libmysqlclient-dev' apt package

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -54,7 +54,8 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               python3.5 python3.5-dev python3.6 python3.6-dev \
               software-properties-common Xvfb libmagickwand-dev openjdk-7-jre \
               dos2unix subversion \
-              aspell aspell-en aspell-es gettext tk-dev libssl-dev lftp"
+              aspell aspell-en aspell-es gettext tk-dev libssl-dev lftp \
+              libmysqlclient-dev"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="watchdog coveralls diff-highlight \


### PR DESCRIPTION
OCA projects are using 'mysqlclient' from requirements.txt
This package requires libmysqlclient-dev in order to avoid the following error:
 - "OSError: mysql_config not found"

Travis has installed 'libmysqlclient-dev' apt package so runbot is
failing but travis is not.

In order to show the same result we are installing this dependency early