### PR TITLE
[FIX] odoo-shippable: Change path of vim to 8.2

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -244,7 +244,7 @@ EOF
 
 # Upgrade & configure vim
 apt install vim --only-upgrade
-wget -q -O /usr/share/vim/vim81/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
+wget -q -O /usr/share/vim/vim82/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
 git_clone_execute "${SPF13_REPO}" "3.0" "bootstrap.sh"
 git_clone_copy "${VIM_OPENERP_REPO}" "master" "vim/" "${HOME}/.vim/bundle/vim-openerp"
 git_clone_copy "${VIM_JEDI_REPO}" "master" "." "${HOME}/.vim/bundle/jedi-vim"


### PR DESCRIPTION
Because of the last version of vim installed changed of path so the hard
coded copy of file is failing