### PR TITLE
[FIX] watchdog dropped support for Python 2.6, 3.2 and 3.3 since 0.10.0

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -58,7 +58,7 @@ DPKG_DEPENDS="postgresql-9.3 postgresql-contrib-9.3 \
               libmysqlclient-dev libcups2-dev emacs byobu"
 PIP_OPTS="--upgrade \
           --no-cache-dir"
-PIP_DEPENDS_EXTRA="watchdog coveralls diff-highlight \
+PIP_DEPENDS_EXTRA="watchdog==0.9.0;python_version<='3.3' watchdog;python_version>'3.3' coveralls diff-highlight \
                    pg-activity virtualenv nodeenv setuptools==33.1.1 \
                    html2text==2016.9.19 ofxparse==0.15 pgcli pre-commit"
 PIP_DPKG_BUILD_DEPENDS=""
@@ -244,7 +244,10 @@ EOF
 
 # Upgrade & configure vim
 apt install vim --only-upgrade
-wget -q -O /usr/share/vim/vim82/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
+# Get vim version
+VIM_VERSION=$(dpkg -s vim | grep Version | sed -n 's/.*\([0-9]\+.[0-9]\+\)\..*/\1/p' | sed -r 's/\.//g')
+
+wget -q -O /usr/share/vim/vim${VIM_VERSION}/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
 git_clone_execute "${SPF13_REPO}" "3.0" "bootstrap.sh"
 git_clone_copy "${VIM_OPENERP_REPO}" "master" "vim/" "${HOME}/.vim/bundle/vim-openerp"
 git_clone_copy "${VIM_JEDI_REPO}" "master" "." "${HOME}/.vim/bundle/jedi-vim"

--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -18,9 +18,9 @@ ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@10.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@10.0 \
                    git+https://github.com/vauxoo/pylint-odoo@master"
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo100/10.0-full_requirements.txt"
-GEOIP2_URLS="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
+GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-ASN_20191224.tar.gz"
 EGENIX_BASE_URL="https://files.pythonhosted.org/packages/66/e6/e0709aedeb4a5c92a1aeb8c47ab50e9506eafc865806801bd3f01d72b671/egenix-mx-base-3.2.9.zip"
 DPKG_DEPENDS="nodejs \
               phantomjs \

--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -19,9 +19,9 @@ ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@11.0 \
                    git+https://github.com/vauxoo/pylint-odoo@master"
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo110/11.0-full_requirements.txt"
-GEOIP2_URLS="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
+GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-ASN_20191224.tar.gz"
 DPKG_DEPENDS="nodejs \
               phantomjs \
               antiword \

--- a/odoo120/scripts/build-image.sh
+++ b/odoo120/scripts/build-image.sh
@@ -14,9 +14,9 @@ NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_8.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
 PHANTOMJS_VERSION="2.1.1"
-GEOIP2_URLS="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
+GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-ASN_20191224.tar.gz"
 DPKG_DEPENDS="nodejs \
               antiword \
               python3-dev \

--- a/odoo130/scripts/build-image.sh
+++ b/odoo130/scripts/build-image.sh
@@ -14,9 +14,9 @@ NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_8.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
 PHANTOMJS_VERSION="2.1.1"
-GEOIP2_URLS="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
+GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-ASN_20191224.tar.gz"
 DPKG_DEPENDS="nodejs \
               antiword \
               python3-dev \

--- a/odoo90/scripts/build-image.sh
+++ b/odoo90/scripts/build-image.sh
@@ -16,13 +16,11 @@ WKHTMLTOX_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.1/wkhtmltox-0.12.1_li
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@8.0 \
                    git+https://github.com/vauxoo/server-tools@8.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@8.0 \
-                   git+https://github.com/vauxoo/odoo-venezuela@8.0 \
-                   git+https://github.com/vauxoo/pylint-odoo@master"
-                   # git+https://github.com/vauxoo/odoo-mexico-v2@8.0 \
+                   git+https://github.com/vauxoo/odoo-venezuela@8.0 "
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo90/9.0-full_requirements.txt"
-GEOIP2_URLS="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
-             https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
+GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \
+             https://s3.vauxoo.com/GeoLite2-ASN_20191224.tar.gz"
 DPKG_DEPENDS="nodejs \
               phantomjs \
               antiword \
@@ -59,7 +57,6 @@ PIP_OPTS="--upgrade \
           --no-cache-dir"
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
                    mercurial==3.2.2 \
-                   setuptools==33.1.1 \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
                    git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
                    hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
@@ -78,7 +75,8 @@ apt-get install ${DPKG_DEPENDS} ${PIP_DPKG_BUILD_DEPENDS}
 npm install ${NPM_OPTS} ${NPM_DEPENDS}
 
 # Update pip 
-pip install --upgrade pip
+pip install --upgrade pip==19.0.1 setuptools==44.0.0
+pip install --no-cache-dir egenix-mx-base
 
 # Let's recursively find our pip dependencies
 collect_pip_dependencies "${ODOO_DEPENDENCIES}" "${PIP_DEPENDS_EXTRA}" "${DEPENDENCIES_FILE}"


### PR DESCRIPTION
- [Watchdog drop support](https://pypi.org/project/watchdog/):

![a](https://screenshots.vauxoo.com/tulio/18014602920-M0nassAKYN.jpg)

- [Geoip license](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/):

![b](https://screenshots.vauxoo.com/tulio/18025002920-a82S3htBBH.jpg)

In the future we can register and get the files, for now we can use the last ones that where public

- Detect installed version of vim and use it for the path to avoid errors on updates

- For some reason 9.0 started to fail because of egenix, since we are not using this version anymoe just froze the dependencies to the ones that worked for the last time