### PR TITLE
[FIX] odoo-shippable: Fixing vim version

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -245,7 +245,7 @@ EOF
 # Upgrade & configure vim
 apt install vim --only-upgrade
 # Get vim version
-VIM_VERSION=$(dpkg -s vim | grep Version | sed -n 's/.*\([0-9]\+.[0-9]\+\)\..*/\1/p' | sed -r 's/\.//g')
+VIM_VERSION=$(dpkg -s vim | grep Version | sed -n 's/.*\([0-9]\+\.[0-9]\+\)\..*/\1/p' | sed -r 's/\.//g')
 
 wget -q -O /usr/share/vim/vim${VIM_VERSION}/spell/es.utf-8.spl http://ftp.vim.org/pub/vim/runtime/spell/es.utf-8.spl
 git_clone_execute "${SPF13_REPO}" "3.0" "bootstrap.sh"


### PR DESCRIPTION
The output now is "Version: 2:8.2.0251-0york0~14.04" then the result was `0~14`
It is because the original regex was not scaped the dot '\.' of the version so it means any character
It is fixed adding scaped dot and now the result is "82"
It is required to copy spell files