### PR TITLE
[REF] odoo-shippable: Update python3.7.6 and check if _sqlite3 is working

### DIFF
--- a/odoo-shippable/scripts/build-image.sh
+++ b/odoo-shippable/scripts/build-image.sh
@@ -94,6 +94,7 @@ cp /tmp/ssh_pylib/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/
 cp /tmp/ssh_pylib/_ssl.cpython-37m-x86_64-linux-gnu.so /usr/local/lib/python3.7/lib-dynload/
 install_py37
 python3.7 -c "import _ssl"
+python3.7 -c "import _sqlite3"
 
 # Upgrade pip for python3
 curl "https://bootstrap.pypa.io/get-pip.py" -o "/tmp/get-pip.py"

--- a/odoo-shippable/scripts/library.sh
+++ b/odoo-shippable/scripts/library.sh
@@ -80,7 +80,7 @@ service_postgres_without_sudo(){
 install_py37(){
     # Based on https://github.com/docker-library/python/blob/7a794688c7246e7eff898f5288716a3e7dc08484/3.7/stretch/Dockerfile
     export GPG_KEY=0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-    export PYTHON_VERSION=3.7.0
+    export PYTHON_VERSION=3.7.6
     wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
     && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
Since that there is travis build result using coverage or pre-commit returning the following error:
File /usr/local/lib/python3.7/sqlite3/dbapi2.py, line 27, in <module>
     from _sqlite3 import *
 ModuleNotFoundError: No module named '_sqlite3'