### PR TITLE
[FIX] Disable pep517.

### DIFF
--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -82,7 +82,7 @@ collect_pip_dependencies "${ODOO_DEPENDENCIES}" "${PIP_DEPENDS_EXTRA}" "${DEPEND
 clean_requirements ${DEPENDENCIES_FILE}
 
 # Install python dependencies
-pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE}
+pip install ${PIP_OPTS} -r ${DEPENDENCIES_FILE} --no-use-pep517
 
 python --version
 


### PR DESCRIPTION
I seems that pep517 is giving some issues with the new versions of pip so the workaround is to [disable it](https://github.com/pypa/pip/pull/6370\#issuecomment-486141788).

Initially found it [here](https://bugs.launchpad.net/mistral/+bug/1867191)


This fixes:

![a](https://screenshots.vauxoo.com/tulio/11204909720-nRsqWc0hTn.jpg)