### PR TITLE
[FIX] Broken links.

### DIFF
--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -12,7 +12,7 @@ set -e
 ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-WKHTMLTOX_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
+WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
 RUBY_VERSION="2.5.3"
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
                    git+https://github.com/vauxoo/server-tools@11.0 \
@@ -75,7 +75,7 @@ PIP_DEPENDS_EXTRA="reqgen \
                    requirements-parser \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
                    git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
-                   hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
+                   sphinxcontrib-youtube"
 
 PIP_DPKG_BUILD_DEPENDS=""
 

--- a/odoo120/scripts/build-image.sh
+++ b/odoo120/scripts/build-image.sh
@@ -63,7 +63,7 @@ PIP_OPTS="--upgrade \
 PIP_DEPENDS_EXTRA="requirements-parser \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
                    git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
-                   hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
+                   sphinxcontrib-youtube"
 
 PIP_DPKG_BUILD_DEPENDS=""
 


### PR DESCRIPTION
- sphinx youtube is nop longer in bitbucker
- wkhtml* legacy versions are hosted in github now, the old url have been deprecated.

This fix:

![a](https://screenshots.vauxoo.com/tulio/14055628820-Rv39iqOf8s.jpg)

And:

![b](https://screenshots.vauxoo.com/tulio/14062828820-cNrcct1Ypv.jpg)

I'm only fixing the images used for current instances, the legacy ones (<11.0) won't be fixed unless needed.