### PR TITLE
[REF] odoo110_py37: Fix PYENV_ROOT environment variable

### DIFF
--- a/odoo110_py37/Dockerfile
+++ b/odoo110_py37/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone https://github.com/pyenv/pyenv.git /usr/share/pyenv && \
     pyenv install $PYENV_VERSION && \
     pyenv shell $PYENV_VERSION && \
     pyenv rehash && \
-    echo "export PYENV_ROOT=/pyenv\nexport PATH=\$PYENV_ROOT/shims:\$PYENV_ROOT/bin:\$PATH" | tee -a /etc/bash.bashrc && \
+    echo "export PYENV_ROOT=$PYENV_ROOT\nexport PATH=\$PYENV_ROOT/shims:\$PYENV_ROOT/bin:\$PATH" | tee -a /etc/bash.bashrc && \
     wget -O /tmp/req11.txt https://raw.githubusercontent.com/odoo/odoo/11.0/requirements.txt && \
     pip --no-cache-dir install -U pip && \
     pip --no-cache-dir install -Ur /tmp/req11.txt && \


### PR DESCRIPTION
Fix the `PYENV_ROOT` environment variable

Before
```bash
export PYENV_ROOT=/pyenv
export PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
```

Notice `/pyenv` doesn't exists

Now
```bash
export PYENV_ROOT=/usr/share/pyenv
export PATH=$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
```