### PR TITLE
[FIX] odoo110: Using wkhtmltopdf 0.12.5-1 recommended by Odoo

### DIFF
--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -12,7 +12,7 @@ set -e
 ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-WKHTMLTOX_URL="https://downloads.wkhtmltopdf.org/0.12/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
+WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@10.0 \
                    git+https://github.com/vauxoo/server-tools@10.0 \
                    git+https://github.com/vauxoo/addons-vauxoo@10.0 \

--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -56,8 +56,7 @@ PIP_OPTS="--upgrade \
 PIP_DEPENDS_EXTRA="requirements-parser==0.1.0 \
                    setuptools==33.1.1 \
                    git+https://github.com/vauxoo/pylint-odoo@master#egg=pylint-odoo \
-                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc \
-                   hg+https://bitbucket.org/birkenfeld/sphinx-contrib@default#egg=sphinxcontrib-youtube&subdirectory=youtube"
+                   git+https://github.com/vauxoo/panama-dv@master#egg=ruc"
 
 PIP_DPKG_BUILD_DEPENDS=""
 

--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -13,10 +13,7 @@ ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
-ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@10.0 \
-                   git+https://github.com/vauxoo/server-tools@10.0 \
-                   git+https://github.com/vauxoo/addons-vauxoo@10.0 \
-                   git+https://github.com/vauxoo/pylint-odoo@master"
+ODOO_DEPENDENCIES=""
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo100/10.0-full_requirements.txt"
 GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
              https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \

--- a/odoo100/scripts/library.sh
+++ b/odoo100/scripts/library.sh
@@ -100,8 +100,8 @@ function collect_pip_dependencies(){
 function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
-    wget -qO- "${URL}" | tar -xJ -C "${DIR}/"
-    mv "${DIR}/wkhtmltox/bin/wkhtmltopdf" "/usr/local/bin/wkhtmltopdf"
+    wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
+    dpkg -i "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
 

--- a/odoo100/scripts/library.sh
+++ b/odoo100/scripts/library.sh
@@ -101,7 +101,7 @@ function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
     wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
-    dpkg -i "${DIR}/wkhtmltox.deb"
+    dpkg -i "${DIR}/wkhtmltox.deb";apt -f install;dpkg -i "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
 

--- a/odoo100/scripts/library.sh
+++ b/odoo100/scripts/library.sh
@@ -101,7 +101,7 @@ function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
     wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
-    dpkg -i "${DIR}/wkhtmltox.deb";apt -f install;dpkg -i "${DIR}/wkhtmltox.deb"
+    apt update && apt install "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
 

--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -12,7 +12,7 @@ set -e
 ARCH="$( dpkg --print-architecture )"
 NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-${ARCH}.tar.xz"
+WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
 RUBY_VERSION="2.5.3"
 ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
                    git+https://github.com/vauxoo/server-tools@11.0 \

--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -14,10 +14,7 @@ NODE_UPSTREAM_REPO="deb http://deb.nodesource.com/node_5.x trusty main"
 NODE_UPSTREAM_KEY="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 WKHTMLTOX_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${DISTRIB_CODENAME}_${ARCH}.deb"
 RUBY_VERSION="2.5.3"
-ODOO_DEPENDENCIES="git+https://github.com/vauxoo/odoo@11.0 \
-                   git+https://github.com/vauxoo/server-tools@11.0 \
-                   git+https://github.com/vauxoo/addons-vauxoo@11.0 \
-                   git+https://github.com/vauxoo/pylint-odoo@master"
+ODOO_DEPENDENCIES=""
 DEPENDENCIES_FILE="/usr/share/vx-docker-internal/odoo110/11.0-full_requirements.txt"
 GEOIP2_URLS="https://s3.vauxoo.com/GeoLite2-City_20191224.tar.gz \
              https://s3.vauxoo.com/GeoLite2-Country_20191224.tar.gz \

--- a/odoo110/scripts/library.sh
+++ b/odoo110/scripts/library.sh
@@ -100,8 +100,8 @@ function collect_pip_dependencies(){
 function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
-    wget -qO- "${URL}" | tar -xJ -C "${DIR}/"
-    mv "${DIR}/wkhtmltox/bin/wkhtmltopdf" "/usr/local/bin/wkhtmltopdf"
+    wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
+    dpkg -i "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
 

--- a/odoo110/scripts/library.sh
+++ b/odoo110/scripts/library.sh
@@ -101,7 +101,7 @@ function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
     wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
-    dpkg -i "${DIR}/wkhtmltox.deb"
+    dpkg -i "${DIR}/wkhtmltox.deb";apt -f install;dpkg -i "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
 

--- a/odoo110/scripts/library.sh
+++ b/odoo110/scripts/library.sh
@@ -101,7 +101,7 @@ function wkhtmltox_install(){
     URL="${1}"
     DIR="$( mktemp -d )"
     wget -qO "${DIR}/wkhtmltox.deb" "${URL}"
-    dpkg -i "${DIR}/wkhtmltox.deb";apt -f install;dpkg -i "${DIR}/wkhtmltox.deb"
+    apt update && apt install "${DIR}/wkhtmltox.deb"
     rm -rf "${DIR}"
 }
 


### PR DESCRIPTION
More info about: [0.12.5-1: recommended for Odoo 10 and later.](https://github.com/odoo/odoo/wiki/Wkhtmltopdf)
