### PR TITLE
[FIX] odoo100, odoo110: Pin less version since that odoo doesn't support newer - vx#13817

### DIFF
--- a/odoo100/scripts/build-image.sh
+++ b/odoo100/scripts/build-image.sh
@@ -47,8 +47,8 @@ DPKG_DEPENDS="nodejs \
               cloc"
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
-NPM_DEPENDS="less \
-             less-plugin-clean-css \
+NPM_DEPENDS="less@3.11.3 \
+             less-plugin-clean-css@1.5.1 \
              jshint"
 PIP_OPTS="--upgrade \
           --no-cache-dir"

--- a/odoo110/scripts/build-image.sh
+++ b/odoo110/scripts/build-image.sh
@@ -62,8 +62,8 @@ DPKG_DEPENDS="nodejs \
 
 DPKG_UNNECESSARY=""
 NPM_OPTS="-g"
-NPM_DEPENDS="less \
-             less-plugin-clean-css \
+NPM_DEPENDS="less@3.12.2 \
+             less-plugin-clean-css@1.5.1 \
              jshint"
 PIP_OPTS="--upgrade \
           --no-cache-dir"


### PR DESCRIPTION
Customer using 10.0 reported the following error:
 - ![image](https://user-images.githubusercontent.com/6644187/111822112-02a2b400-88a9-11eb-99a9-6684c0b408df.png)

Another customer in 11.0


Checking old version vs new on in odoo-11.0:

`docker run -it --rm vauxoo/odoo-110-image npm -g list |grep less`

```txt
├─┬ less@4.1.1
├─┬ less-plugin-clean-css@1.5.1
  │ ├── caseless@0.11.0
```

`docker run -it --rm vauxoo/odoo-110-image:wk_0_12_4 npm -g list |grep less`

```txt
├─┬ less@3.12.2
├─┬ less-plugin-clean-css@1.5.1
  │ ├── caseless@0.11.0
```

Same for odoo-10.0:

`docker run -it --rm vauxoo/odoo-100-image:wk_0_12_4 npm -g list |grep less`

```txt
├─┬ less@3.11.3
│ │ ├── caseless@0.12.0
├─┬ less-plugin-clean-css@1.5.1
  │ ├── caseless@0.11.0
```

`docker run -it --rm vauxoo/odoo-100-image npm -g list |grep less`

```txt
├─┬ less@4.1.1
├─┬ less-plugin-clean-css@1.5.1
  │ ├── caseless@0.11.0
```

It looks like less >= 4.0.0 issue
 - https://github.com/navikt/nav-frontend-moduler/issues/934

So, pinning the version compatible to fix the issue is a good idea for this case