### PR TITLE
[REF] odoo110_py37: Add odoo cron service

### DIFF
--- a/odoo110_py37/Dockerfile
+++ b/odoo110_py37/Dockerfile
@@ -3,6 +3,8 @@ FROM vauxoo/odoo-140-image
 ENV PYENV_ROOT=/usr/share/pyenv \
     PYENV_VERSION=3.7.10 \
     PATH=/usr/share/pyenv/shims:/usr/bin:$PATH
+COPY files/odoo_cron_service.conf /etc/supervisor/conf.d/
+
 RUN git clone https://github.com/pyenv/pyenv.git /usr/share/pyenv && \
     cd /usr/share/pyenv && src/configure && make -C src && \
     ln -sf /usr/share/pyenv/bin/pyenv /usr/bin/pyenv && \

--- a/odoo110_py37/files/odoo_cron_service.conf
+++ b/odoo110_py37/files/odoo_cron_service.conf
@@ -1,8 +1,9 @@
 [program:odoo_cron]
 environment =
-    ODOO_QUEUE_JOB_CHANNELS='root:4,root.sales:4,root.emails:4'
+    ODOO_QUEUE_JOB_CHANNELS="root:4,root.sales:4,root.emails:4",
+    ODOO_QUEUE_JOB_PORT="8076"
 user=odoo
-command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --no-http --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid --load=web,queue_job
+command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --xmlrpc-port=8076 --longpolling-port=8077 --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid --load=web,queue_job
 stdout_logfile=/var/log/supervisor/odoo_cron_stdout.log
 stderr_logfile=/var/log/supervisor/odoo_cron_stdout.log
 stdout_logfile_maxbytes=10MB

--- a/odoo110_py37/files/odoo_cron_service.conf
+++ b/odoo110_py37/files/odoo_cron_service.conf
@@ -1,4 +1,6 @@
 [program:odoo_cron]
+environment =
+    ODOO_QUEUE_JOB_CHANNELS='root:4,root.sales:4,root.emails:4'
 user=odoo
 command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --no-http --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid
 stdout_logfile=/var/log/supervisor/odoo_cron_stdout.log

--- a/odoo110_py37/files/odoo_cron_service.conf
+++ b/odoo110_py37/files/odoo_cron_service.conf
@@ -7,4 +7,4 @@ stdout_logfile_maxbytes=1000MB
 autostart=true
 autorestart=true
 exitcodes=0,2
-startsecs=65
+startsecs=900

--- a/odoo110_py37/files/odoo_cron_service.conf
+++ b/odoo110_py37/files/odoo_cron_service.conf
@@ -1,0 +1,10 @@
+[program:odoo_cron]
+user=odoo
+command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --no-http --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid
+stdout_logfile=/var/log/supervisor/odoo_stdout.log
+stderr_logfile=/var/log/supervisor/odoo_stdout.log
+stdout_logfile_maxbytes=1000MB
+autostart=true
+autorestart=true
+exitcodes=0,2
+startsecs=65

--- a/odoo110_py37/files/odoo_cron_service.conf
+++ b/odoo110_py37/files/odoo_cron_service.conf
@@ -1,9 +1,9 @@
 [program:odoo_cron]
 user=odoo
 command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --no-http --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid
-stdout_logfile=/var/log/supervisor/odoo_stdout.log
-stderr_logfile=/var/log/supervisor/odoo_stdout.log
-stdout_logfile_maxbytes=1000MB
+stdout_logfile=/var/log/supervisor/odoo_cron_stdout.log
+stderr_logfile=/var/log/supervisor/odoo_cron_stdout.log
+stdout_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 exitcodes=0,2

--- a/odoo110_py37/files/odoo_cron_service.conf
+++ b/odoo110_py37/files/odoo_cron_service.conf
@@ -2,7 +2,7 @@
 environment =
     ODOO_QUEUE_JOB_CHANNELS='root:4,root.sales:4,root.emails:4'
 user=odoo
-command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --no-http --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid
+command=/home/odoo/instance/odoo/odoo-bin -c /home/odoo/.openerp_serverrc --no-http --workers=0 --max-cron-threads=10 --pidfile=/tmp/odoo_cron.pid --load=web,queue_job
 stdout_logfile=/var/log/supervisor/odoo_cron_stdout.log
 stderr_logfile=/var/log/supervisor/odoo_cron_stdout.log
 stdout_logfile_maxbytes=10MB


### PR DESCRIPTION
Odoo using workers has a limit-timeout-real affecting the cron ones
So, the current solution is increasing the timeout

The first solution was using:
 - limit_time_real_cron=0

But it raised the following error:

    2021-03-25 15:28:49,497 47 ERROR DB odoo.service.server: Worker (47) Exception occured, exiting...
    Traceback (most recent call last):
    File "/home/odoo/instance/odoo/odoo/service/server.py", line 843, in run
        t.join()
    File "/usr/share/pyenv/versions/3.7.10/lib/python3.7/threading.py", line 1044, in join
        self._wait_for_tstate_lock()
    File "/usr/share/pyenv/versions/3.7.10/lib/python3.7/threading.py", line 1060, in _wait_for_tstate_lock
        elif lock.acquire(block, timeout):
    File "/home/odoo/instance/odoo/odoo/service/server.py", line 771, in signal_time_expired_handler
        raise Exception('CPU time limit exceeded.')
            Exception: CPU time limit exceeded.

So, it is not working as expected

A second option could be increasing the following parameters:

    limit_time_cpu
    limit_time_real

But it affects the real users timeout and the workers could be used for a long time
And the instance go down.

Another solution is avoid making crons spending a long time but it will a hard work

Another solution is deploying manually but we need to avoid that as possible


I realized that odoo.sh has a low value in the limit times and the `ps aux | grep odoo-bin` service is disabled the crons
Even the crons are running so I think they are using a similar behaviour

The path is based on:
 - https://git.vauxoo.com/deployv/deployv-static/-/blob/26b1bad48a2669ae78a29973f708160e96bd2862/deployv_static/templates/supervisord_service.conf#L18

dummy MR in customer project MR-68