### PR TITLE
[ADD] odoo-shippable: add env var to avoid numpy weird errors

### DIFF
--- a/odoo-shippable/Dockerfile
+++ b/odoo-shippable/Dockerfile
@@ -5,7 +5,8 @@ ENV RUN_COMMAND_MQT_10_ENTRYPOINT_IMAGE="/entrypoint_image" \
     INSTANCE_ALIVE="1" PSQL_VERSION="9.6" \
     REPO_REQUIREMENTS="/.repo_requirements" \
     WITHOUT_DEPENDENCIES="1" OCA_RUNBOT="1" \
-    REPO_CACHED="/.repo_requirements"
+    REPO_CACHED="/.repo_requirements" \
+    OPENBLAS_NUM_THREADS=1
 ARG IS_TRAVIS=false
 COPY scripts/entrypoint_image /
 COPY scripts/*.sh /usr/share/vx-docker-internal/odoo-shippable/


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, if numpy is available in the modules even if you are not using it
Odoo try to compile and the system is down only for a type of processor

Currently we know 2 server reproducing the error:

    B&F-production
    Runbot

More info about:

https://github.com/numpy/numpy/issues/17674
https://github.com/numpy/numpy/issues/17759

It is reproducing in the following MR:

https://git.vauxoo.com/vauxoo/lasec/-/merge_requests/197

Check the following discussion https://odoo-community.org/groups/contributors-15/contributors-186006?mode=thread&date_begin=&date_end=

OpenBLAS creates a number of threads equal to the number of core threads available: 56 in my case (production server),
so it quickly reached limit_memory_hard
and the process was killed (SIGSEGV)
Forcing OPENBLAS_NUM_THREADS=1 fixed the issue.

Current behavior before PR:
Weird errors related to numpy.

Desired behavior after PR is merged:
No errors related to numpy.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

